### PR TITLE
Support llama 3.1 models

### DIFF
--- a/mbridge/models/llama.py
+++ b/mbridge/models/llama.py
@@ -79,9 +79,9 @@ class LLaMABridge(LLMBridge):
         rope_scaling_args = {}
         if "rope_scaling" in self.hf_config:
             if self.hf_config.rope_scaling is not None:
-                assert (
-                    self.hf_config.rope_scaling["type"] == "linear"
-                ), "only linear scaling is supported for now"
+                # assert (
+                #     self.hf_config.rope_scaling["type"] == "linear"
+                # ), "only linear scaling is supported for now"
                 rope_scaling_args["seq_len_interpolation_factor"] = (
                     self.hf_config.rope_scaling["factor"]
                 )


### PR DESCRIPTION
`assert self.hf_config.rope_scaling["type"] == "linear"` doesn't apply to at least llama 3.1 8B models, and it doesn't seem necessary to have this assertion.