### PR TITLE
add Mimo-7B-RL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Currently supported models:
 - [x] DeepseekV3
 - [x] Mixtral
 - [x] Qwen2.5-VL
+- [x] Mimo
 
 
 ## Examples

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,7 @@ bridge.save_weights(model, "path/to/save/model", memory_efficient=False) # 如�
 - [x] DeepseekV3
 - [x] Mixtral
 - [x] Qwen2.5-VL
+- [x] Mimo
 
 ## 示例
 

--- a/mbridge/core/auto_bridge.py
+++ b/mbridge/core/auto_bridge.py
@@ -11,7 +11,7 @@ class AutoBridge:
     """
 
     @classmethod
-    def from_pretrained(cls, hf_model_path) -> Bridge:
+    def from_pretrained(cls, hf_model_path, trust_remote_code=False) -> Bridge:
         """
         Loads the appropriate bridge class from a pretrained model path.
 
@@ -21,7 +21,7 @@ class AutoBridge:
         Returns:
             Bridge: An instance of the appropriate bridge class for the model
         """
-        config = AutoConfig.from_pretrained(hf_model_path, trust_remote_code=True)
+        config = AutoConfig.from_pretrained(hf_model_path, trust_remote_code=trust_remote_code)
 
         return cls.from_config(config)
 

--- a/mbridge/core/auto_bridge.py
+++ b/mbridge/core/auto_bridge.py
@@ -21,7 +21,7 @@ class AutoBridge:
         Returns:
             Bridge: An instance of the appropriate bridge class for the model
         """
-        config = AutoConfig.from_pretrained(hf_model_path)
+        config = AutoConfig.from_pretrained(hf_model_path, trust_remote_code=True)
 
         return cls.from_config(config)
 

--- a/mbridge/models/__init__.py
+++ b/mbridge/models/__init__.py
@@ -11,10 +11,12 @@ Classes:
     Qwen3Bridge: Bridge implementation for Qwen3 models
     LLaMA2Bridge: Bridge implementation for LLaMA2 models
     DeepseekV3Bridge: Bridge implementation for DeepseekV3 models
+    MimoBridge: Bridge implementation for MIMO models
 """
 
 from .deepseek_v3 import DeepseekV3Bridge
 from .llama import LLaMABridge
+from .mimo import MimoBridge
 from .mixtral import MixtralBridge
 from .qwen2 import Qwen2Bridge
 from .qwen2_5_vl import Qwen2_5VLBridge

--- a/mbridge/models/mimo.py
+++ b/mbridge/models/mimo.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
+
 from ..core import register_model
 from .qwen2 import Qwen2Bridge
 
@@ -14,6 +16,91 @@ class MimoBridge(Qwen2Bridge):
     optimizations for Mimo models, handling the conversion between
     Hugging Face Mimo format and Megatron-Core.
     
-    TODO: MTP layer is still WIP.
+    MiMo adds MTP (Multi-Token Prediction) layers on top of Qwen2 architecture.
     """
+    
+    def _build_config(self):
+        """Override to add MTP configuration."""
+        hf_config = self.hf_config
+        
+        # Add MTP configuration if present
+        mtp_args = {}
+        if "num_nextn_predict_layers" in hf_config:
+            mtp_args["mtp_num_layers"] = hf_config.num_nextn_predict_layers
+            mtp_args["mtp_loss_scaling_factor"] = 0.1
+        
+        return self._build_base_config(
+            add_qkv_bias=True,
+            qk_layernorm=False,
+            **mtp_args,
+        )
+    
+    def _get_gptmodel_args(self) -> dict:
+        """Override to add MTP block spec if needed."""
+        ret = super()._get_gptmodel_args()
+        
+        # Add MTP block spec if MTP layers are present
+        if self.config.mtp_num_layers is not None:
+            transformer_layer_spec = self.config
+            mtp_block_spec = get_gpt_mtp_block_spec(
+                self.config, transformer_layer_spec, use_transformer_engine=True
+            )
+            ret["mtp_block_spec"] = mtp_block_spec
+            
+        return ret
+    
+    def _weight_name_mapping_mcore_to_hf(self, mcore_weights_name: str) -> list[str]:
+        """Override to handle MTP layer mappings."""
+        # Check if this is an MTP layer weight
+        if "mtp" in mcore_weights_name:
+            return self._convert_mtp_param(mcore_weights_name)
+        
+        # Otherwise use parent class mapping
+        return super()._weight_name_mapping_mcore_to_hf(mcore_weights_name)
+    
+    def _convert_mtp_param(self, name: str) -> list[str]:
+        """
+        Convert MTP layer parameters from MCore to HF format.
+        
+        Following DeepSeek V3's approach, MTP layers can contain:
+        - Direct mapped components (LayerNorms, projections)
+        - Transformer components that reuse existing attention/MLP mappings
+        
+        Args:
+            name: MCore parameter name containing "mtp"
+            
+        Returns:
+            list: Corresponding HF parameter names
+        """
+        # For now, assume single MTP layer support
+        if "mtp_layers." not in name:
+            raise NotImplementedError(f"Invalid MTP parameter name: {name}")
+        
+        # Get the MTP layer index
+        parts = name.split(".")
+        mtp_layer_idx = parts[2]  # mtp.layers.{idx}
+        
+        # Direct mappings for MTP-specific components
+        direct_name_mapping = {
+            f"mtp.layers.{mtp_layer_idx}.input_layernorm.weight": f"model.mtp_layers.{mtp_layer_idx}.input_layernorm.weight",
+            f"mtp.layers.{mtp_layer_idx}.post_attention_layernorm.weight": f"model.mtp_layers.{mtp_layer_idx}.post_attention_layernorm.weight",
+            f"mtp.layers.{mtp_layer_idx}.token_layernorm.weight": f"model.mtp_layers.{mtp_layer_idx}.token_layernorm.weight",
+            f"mtp.layers.{mtp_layer_idx}.hidden_layernorm.weight": f"model.mtp_layers.{mtp_layer_idx}.hidden_layernorm.weight",
+            f"mtp.layers.{mtp_layer_idx}.final_layernorm.weight": f"model.mtp_layers.{mtp_layer_idx}.final_layernorm.weight",
+            f"mtp.layers.{mtp_layer_idx}.input_proj.weight": f"model.mtp_layers.{mtp_layer_idx}.input_proj.weight",
+        }
+        
+        if name in direct_name_mapping:
+            return [direct_name_mapping[name]]
+        
+        # Handle transformer components within MTP
+        # Check if this is a self_attention or mlp component
+        if "self_attention" in name or "input_layernorm.weight" in name:
+            convert_names = self._weight_name_mapping_attention(name)
+        elif "mlp" in name:
+            convert_names = self._weight_name_mapping_mlp(name)
+        else:
+            raise NotImplementedError(f"Unsupported MTP parameter name: {name}")
+        return convert_names
+
 

--- a/mbridge/models/mimo.py
+++ b/mbridge/models/mimo.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+
+from ..core import register_model
+from .qwen2 import Qwen2Bridge
+
+
+@register_model("mimo")
+class MimoBridge(Qwen2Bridge):
+    """
+    Bridge implementation for Mimo models.
+
+    This class extends Qwen2Bridge to provide specific configurations and
+    optimizations for Mimo models, handling the conversion between
+    Hugging Face Mimo format and Megatron-Core.
+    
+    TODO: MTP layer is still WIP.
+    """
+

--- a/memory_estimator/webui/main.py
+++ b/memory_estimator/webui/main.py
@@ -48,6 +48,7 @@ SUPPORTED_MODELS = [
     "moonshotai/Moonlight-16B-A3B",
     "moonshotai/Kimi-K2-Instruct",
     "deepseek-ai/DeepSeek-V3",
+    "XiaomiMiMo/MiMo-7B-RL",
 ]
 
 


### PR DESCRIPTION
Support Mimo-7B-RL support. 
MTP for Mimo is under further testing.

```
/root/Megatron-LM/megatron/core/models/gpt/gpt_layer_specs.py:104: UserWarning: The fp8 argument in "get_gpt_layer_with_transformer_engine_spec" has been deprecated and will be removed soon. Please update your code accordingly.
  warnings.warn(
/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/cpu_offload.py:670: DeprecationWarning: Offloading weights is deprecated. Using offload_weights=True does not have any effect.
  warnings.warn(
 > number of parameters on (tensor, pipeline) model parallel rank (0, 0): 7622619136
Model loaded: /root/MiMo-7B-RL
saving checkpoint at iteration       1 to /root/MiMo-7B-RL_torch_dist in torch_dist format
WARNING:megatron.core.rerun_state_machine:Implicit initialization of Rerun State Machine!
WARNING:megatron.core.rerun_state_machine:RerunStateMachine initialized in mode disabled
Storing distributed optimizer sharded state of type fully_sharded_model_space
/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py:4631: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. 
  warnings.warn(  # warn only once
  successfully saved checkpoint from iteration       1 to /root/MiMo-7B-RL_torch_dist [ t 1/1, p 1/1 ]
```