### PR TITLE
Feat: Add automatic dtype conversion for FP32 HuggingFace weights to target dtype

### DIFF
--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -703,6 +703,14 @@ class Bridge(ABC):
         Raises:
             NotImplementedError: If the parameter name is unsupported
         """
+        # Convert weights to the target dtype if needed
+        # This handles cases where HF weights are FP32 but model expects BF16/FP16
+        if hasattr(self, 'dtype') and self.dtype is not None:
+            hf_weights = [
+                w.to(self.dtype) if w.dtype != self.dtype else w 
+                for w in hf_weights
+            ]
+        
         if len(hf_weights) == 1:
             return hf_weights[0]
         if (


### PR DESCRIPTION
 ## Problem

 - When converting HuggingFace models with FP32 weights to Megatron format with BF16/FP16 precision, the conversion fails with:
`ValueError: Invalid usage of tensors with different dtypes Found torch.bfloat16 and torch.float32`

- This occurs during the torch.distributed.scatter operation because the loaded HF weights (FP32) don't match the expected model dtype (BF16/FP16).

 ## Solution

 This PR adds automatic dtype conversion in the` _weight_to_mcore_format` method to convert HuggingFace weights to the target dtype specified in the Bridge initialization.

## Changes

  - Modified mbridge/core/bridge.py:
    - Added dtype conversion logic in _weight_to_mcore_format method
    - Converts weights only when needed (checks if dtype mismatch exists)
    - Uses the existing self.dtype attribute from Bridge class