### PR TITLE
support tie_word_embeddings for pp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ local/
 wandb/
 onelogger.log
 onelogger.err
+.env

--- a/example/2.load_model_and_export_multiple_gpus.py
+++ b/example/2.load_model_and_export_multiple_gpus.py
@@ -178,6 +178,9 @@ def main():
     if torch.distributed.get_rank() == 0:
         print(f"missing keys: {missing_keys}")
         print(f"not_matched_keys: {not_matched_keys}")
+
+    # wait for save finish
+    torch.distributed.barrier()
     torch.distributed.destroy_process_group()
 
 

--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -49,7 +49,7 @@ class Bridge(ABC):
         self.config = self._build_config()
         self.safetensor_io = None
 
-        self._change_mapping_from_config(self.hf_config)
+        self._adjust_mapping_for_shared_weights(self.hf_config)
 
     def get_model(
         self,
@@ -577,7 +577,7 @@ class Bridge(ABC):
         "output_layer.weight": "lm_head.weight",
     }
 
-    def _change_mapping_from_config(self, hf_config: AutoConfig):
+    def _adjust_mapping_for_shared_weights(self, hf_config: AutoConfig):
         pass
 
     def _get_hf_shared_weight_keys(self) -> list[str]:

--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -49,6 +49,8 @@ class Bridge(ABC):
         self.config = self._build_config()
         self.safetensor_io = None
 
+        self._change_mapping_from_config(self.hf_config)
+
     def get_model(
         self,
         weight_path: str = None,
@@ -250,7 +252,7 @@ class Bridge(ABC):
         )
         rank = torch.distributed.get_rank() if is_distributed else 0
         if not os.path.exists(weights_path):
-            os.makedirs(weights_path)
+            os.makedirs(weights_path, exist_ok=True)
         per_tensor_generator = self.export_weights(models)
         if rank != 0:
             for _, _ in per_tensor_generator:
@@ -262,7 +264,11 @@ class Bridge(ABC):
                     per_tensor_generator, weights_path
                 )
             else:
-                self.safetensor_io.save_hf_weight(per_tensor_generator, weights_path)
+                self.safetensor_io.save_hf_weight(
+                    per_tensor_generator,
+                    weights_path,
+                    self._get_hf_shared_weight_keys(),
+                )
             self.safetensor_io.save_index(weights_path)
             self.hf_config.save_pretrained(weights_path)
         return
@@ -570,6 +576,12 @@ class Bridge(ABC):
         "decoder.final_layernorm.weight": "model.norm.weight",
         "output_layer.weight": "lm_head.weight",
     }
+
+    def _change_mapping_from_config(self, hf_config: AutoConfig):
+        pass
+
+    def _get_hf_shared_weight_keys(self) -> list[str]:
+        return []
 
     def _weight_name_mapping_mlp(self, name: str) -> list[str]:
         """

--- a/mbridge/core/safetensor_io.py
+++ b/mbridge/core/safetensor_io.py
@@ -84,6 +84,7 @@ class SafeTensorIO:
         self,
         per_tensor_generator: Generator[tuple[str, torch.Tensor], None, None],
         new_hf_dir: str,
+        hf_shared_weight_keys: list[str],
     ):
         """
         This function is used to save weights to a safetensors file.
@@ -113,7 +114,9 @@ class SafeTensorIO:
                     save_file(to_save, safetensor_file)
                     for k in keys_for_file:
                         del states[k]
-        assert len(states) == 0, f"Some weights are not saved: {states.keys()}"
+        assert set(states.keys()) == set(
+            hf_shared_weight_keys
+        ), f"Some weights are not saved: {states.keys()} {hf_shared_weight_keys=}"
         return
 
     def save_hf_weight_memory_efficient(

--- a/mbridge/models/qwen2.py
+++ b/mbridge/models/qwen2.py
@@ -55,12 +55,14 @@ class Qwen2Bridge(LLMBridge):
         "mlp.linear_fc2.weight": ["model.layers.{layer_number}.mlp.down_proj.weight"],
     }
 
-    def _change_mapping_from_config(self, hf_config: AutoConfig):
+    def _adjust_mapping_for_shared_weights(self, hf_config: AutoConfig):
         if getattr(hf_config, "tie_word_embeddings", False):
             self._DIRECT_MAPPING["output_layer.weight"] = "model.embed_tokens.weight"
     
     def _get_hf_shared_weight_keys(self):
-        return ["model.embed_tokens.weight"]
+        if getattr(hf_config, "tie_word_embeddings", False):
+            return ["model.embed_tokens.weight"]
+        return []
 
     def _build_config(self):
         """

--- a/mbridge/models/qwen2.py
+++ b/mbridge/models/qwen2.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+from transformers import AutoConfig
+
 from ..core import LLMBridge, register_model
 
 
@@ -52,6 +54,13 @@ class Qwen2Bridge(LLMBridge):
         ],
         "mlp.linear_fc2.weight": ["model.layers.{layer_number}.mlp.down_proj.weight"],
     }
+
+    def _change_mapping_from_config(self, hf_config: AutoConfig):
+        if getattr(hf_config, "tie_word_embeddings", False):
+            self._DIRECT_MAPPING["output_layer.weight"] = "model.embed_tokens.weight"
+    
+    def _get_hf_shared_weight_keys(self):
+        return ["model.embed_tokens.weight"]
 
     def _build_config(self):
         """

--- a/mbridge/models/qwen2_5_vl/__init__.py
+++ b/mbridge/models/qwen2_5_vl/__init__.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Callable, Generator, Optional
 
 import torch
+from transformers import AutoConfig
 
 from ...core import VLMBridge, register_model
 from ...core.util import unwrap_model
@@ -104,6 +105,13 @@ class Qwen2_5VLBridge(VLMBridge):
             "visual.blocks.{layer_number}.norm2.weight"
         ],
     }
+
+    def _change_mapping_from_config(self, hf_config: AutoConfig):
+        if getattr(hf_config, "tie_word_embeddings", False):
+            self._DIRECT_MAPPING["language_model.output_layer.weight"] = "model.embed_tokens.weight"
+
+    def _get_hf_shared_weight_keys(self):
+        return ["model.embed_tokens.weight"]
 
     def _weight_name_mapping_attention(self, name: str) -> list[str]:
         split_name = name.split(".")

--- a/mbridge/models/qwen2_5_vl/__init__.py
+++ b/mbridge/models/qwen2_5_vl/__init__.py
@@ -106,12 +106,14 @@ class Qwen2_5VLBridge(VLMBridge):
         ],
     }
 
-    def _change_mapping_from_config(self, hf_config: AutoConfig):
+    def _adjust_mapping_for_shared_weights(self, hf_config: AutoConfig):
         if getattr(hf_config, "tie_word_embeddings", False):
             self._DIRECT_MAPPING["language_model.output_layer.weight"] = "model.embed_tokens.weight"
 
     def _get_hf_shared_weight_keys(self):
-        return ["model.embed_tokens.weight"]
+        if getattr(hf_config, "tie_word_embeddings", False):
+            return ["model.embed_tokens.weight"]
+        return []
 
     def _weight_name_mapping_attention(self, name: str) -> list[str]:
         split_name = name.split(".")


### PR DESCRIPTION
When `tie_word_embeddings` is set to `True`, enabling pipeline parallelism (PP) may cause the following issues:

1. When `tie_word_embeddings` is `True`, data cannot be directly retrieved from `lm_head.weight`.
2. During `save_weights`, the `makedirs` operation is performed in a multi-process manner, which may occasionally result in errors.
3. When saving Hugging Face weights using `save_hf_weight`, there is a possibility of encountering duplicate weights. It is recommended to add an `assert` statement to verify this.