### PR TITLE
add checkpoint conversion mapping from megatron to huggingface

### DIFF
--- a/mbridge/core/safetensor_io.py
+++ b/mbridge/core/safetensor_io.py
@@ -36,6 +36,14 @@ class SafeTensorIO:
         mapping_hf_weight_names = {k: k for k in hf_weight_names}
         return hf_weight_names, mapping_hf_weight_names
 
+    def _mapping_mlm_weight_names(
+        self,
+        hf_weight_names: list[str],
+    ) -> tuple[list[str], dict[str, str]]:
+        # new_hf_weight_names -> old_hf_weight_names
+        mapping_hf_weight_names = {k: k for k in hf_weight_names}
+        return hf_weight_names, mapping_hf_weight_names
+
     def load_some_hf_weight(self, hf_weight_names: list[str]) -> dict:
         hf_weight_names, mapping_hf_weight_names = self._mapping_hf_weight_names(
             hf_weight_names
@@ -155,10 +163,11 @@ class SafeTensorIO:
             save_file({hf_weight_name: tensor}, tmp_filename)
         for filename, keys_for_file in filename_to_keys_map.items():
             states = {}
-            for key in keys_for_file:
-                tmp_filename = f"{new_hf_dir}/{key}.safetensors"
+            old_keys_for_file, _ = self._mapping_mlm_weight_names(keys_for_file)
+            for old_key, key in zip(old_keys_for_file, keys_for_file):
+                tmp_filename = f"{new_hf_dir}/{old_key}.safetensors"
                 with safe_open(tmp_filename, framework="pt", device="cpu") as f:
-                    states[key] = f.get_tensor(key)
+                    states[key] = f.get_tensor(old_key)
                     os.remove(tmp_filename)
             save_file(states, os.path.join(new_hf_dir, filename))
         return

--- a/mbridge/models/qwen2_5_vl/__init__.py
+++ b/mbridge/models/qwen2_5_vl/__init__.py
@@ -36,6 +36,27 @@ class Qwen2_5VLSafeTensorIO(SafeTensorIO):
             mapping_hf_weight_names[new_hf_weight_name] = hf_weight_name
         return ret_hf_weight_names, mapping_hf_weight_names
 
+    def _mapping_mlm_weight_names(
+        self,
+        hf_weight_names: list[str],
+    ) -> tuple[list[str], dict[str, str]]:
+        ret_hf_weight_names = []
+        mapping_hf_weight_names = {}
+        for hf_weight_name in hf_weight_names:
+            new_hf_weight_name = hf_weight_name
+            if hf_weight_name in self.index:
+                if new_hf_weight_name.startswith("model.language_model."):
+                    new_hf_weight_name = new_hf_weight_name.replace(
+                        "model.language_model.", "model."
+                    )
+                elif new_hf_weight_name.startswith("model.visual."):
+                    new_hf_weight_name = new_hf_weight_name.replace(
+                        "model.visual.", "visual."
+                    )
+            ret_hf_weight_names.append(new_hf_weight_name)
+            mapping_hf_weight_names[new_hf_weight_name] = hf_weight_name
+        return ret_hf_weight_names, mapping_hf_weight_names
+
 
 @register_model("qwen2_5_vl")
 class Qwen2_5VLBridge(VLMBridge):


### PR DESCRIPTION
There are bugs when convert the checkpoint of qwen2.5vl from megatron to huggingface. The bugs are about "no such file or directory: model.language_model.*.safetensors". Need to add checkpoint conversion mapping from megatron to huggingface. 