### PR TITLE
Vision models pass kwargs to self.language_model

### DIFF
--- a/mbridge/models/gemma3/model.py
+++ b/mbridge/models/gemma3/model.py
@@ -260,6 +260,7 @@ class Gemma3Model(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         *,
         inference_params: Optional[BaseInferenceContext] = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Forward function of the LLaVA model.
 
@@ -371,6 +372,7 @@ class Gemma3Model(MegatronModule):
             inference_context=inference_context,
             runtime_gather_output=runtime_gather_output,
             packed_seq_params=packed_seq_params,
+            **kwargs,
         )
 
         return output

--- a/mbridge/models/glm4_vl/model.py
+++ b/mbridge/models/glm4_vl/model.py
@@ -135,6 +135,7 @@ class Glm4VLModel(MegatronModule, VLMixin):
         image_grid_thw: torch.Tensor = None,
         video_grid_thw: torch.Tensor = None,
         runtime_gather_output=False,
+        **kwargs,
     ) -> torch.Tensor:
         """Forward function of the Qwen2VL model.
 
@@ -206,6 +207,7 @@ class Glm4VLModel(MegatronModule, VLMixin):
             inference_context=inference_context,
             runtime_gather_output=runtime_gather_output,
             **(extra_block_kwargs or {}),
+            **kwargs,
         )
 
         return output

--- a/mbridge/models/internvl3/model.py
+++ b/mbridge/models/internvl3/model.py
@@ -173,6 +173,7 @@ class InternVLModel(MegatronModule):
         inference_params: InferenceParams = None,
         packed_seq_params: PackedSeqParams = None,
         image_token_index: int = -1,
+        **kwargs,
     ) -> torch.Tensor:
         use_inference_kv_cache = (
             inference_params is not None
@@ -223,6 +224,7 @@ class InternVLModel(MegatronModule):
             labels=labels,
             inference_params=inference_params,
             packed_seq_params=packed_seq_params,
+            **kwargs,
         )
 
         return output

--- a/mbridge/models/qwen2_5_vl/model.py
+++ b/mbridge/models/qwen2_5_vl/model.py
@@ -209,6 +209,7 @@ class Qwen2_5VLModel(MegatronModule):
         pixel_values_videos: torch.Tensor = None,
         image_grid_thw: torch.Tensor = None,
         video_grid_thw: torch.Tensor = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Forward function of the Qwen2VL model.
 
@@ -353,6 +354,7 @@ class Qwen2_5VLModel(MegatronModule):
             # inference_params=inference_params,  # currently always None
             packed_seq_params=packed_seq_params,  # currently always None
             **(extra_block_kwargs or {}),
+            **kwargs,
         )
 
         return output

--- a/mbridge/models/qwen3_vl/model.py
+++ b/mbridge/models/qwen3_vl/model.py
@@ -206,6 +206,7 @@ class Qwen3VLModel(MegatronModule):
         video_grid_thw: torch.Tensor = None,
         # cat set at dataset
         image_input_mask: torch.Tensor = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Forward function of the Qwen3VL model.
 
@@ -328,6 +329,7 @@ class Qwen3VLModel(MegatronModule):
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
             **(extra_block_kwargs or {}),
+            **kwargs,
         )
 
         return output


### PR DESCRIPTION
So that monkey patches which add additional parameters to the patch can get correctly
passed to the self.language_model, e.g. the `temperature` for Verl's fused forward.

Without this, we will get the following error in Verl:
https://github.com/volcengine/verl/actions/runs/18718511219/job/53384277976