### PR TITLE
fix: when hf_config has head_dim but the value is None

### DIFF
--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -780,7 +780,7 @@ class Bridge(ABC):
             num_attention_heads = self.hf_config.num_attention_heads
             head_dim = getattr(
                 self.hf_config, "head_dim", hidden_dim // num_attention_heads
-            )
+            ) or hidden_dim // num_attention_heads
             out_shape = (
                 [num_key_value_heads, -1, hidden_dim]
                 if ".bias" not in mcore_weights_name
@@ -868,7 +868,7 @@ class Bridge(ABC):
             num_attention_heads = self.hf_config.num_attention_heads
             head_dim = getattr(
                 self.hf_config, "head_dim", hidden_dim // num_attention_heads
-            )
+            ) or hidden_dim // num_attention_heads
             group_dim = head_dim * num_attention_heads // num_key_value_heads
             q, k, v = hf_weights
             # q k v might be tp split


### PR DESCRIPTION
I tried to convert a mixtral-8x7B model from hf to mcore. However, the conversion failed with error:
```
[rank4]:   File "/root/mbridge/mbridge/core/bridge.py", line 872, in _weight_to_mcore_format
[rank4]:     group_dim = head_dim * num_attention_heads // num_key_value_heads
[rank4]: TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

This PR fixes this issue where hf_config has head_dim but the value is None, causing the default value in `getattr` to be ignored.