### PR TITLE
fix bugs in save_hf_weight_memory_efficient when there is only one sa…

### DIFF
--- a/mbridge/core/safetensor_io.py
+++ b/mbridge/core/safetensor_io.py
@@ -21,6 +21,14 @@ class SafeTensorIO:
                 origin_index = json.load(f)
                 self.index = origin_index["weight_map"]
                 self.origin_index = origin_index
+        else:
+            src_files = glob(os.path.join(hf_dir, '*.safetensors'))
+            if len(src_files) == 1:
+                for file in src_files:
+                    with safe_open(file, framework="pt", device="cpu") as f:
+                        filename = os.path.basename(file)
+                        for key in f.keys():
+                            self.index[key] = filename
 
         self.hf_dir = hf_dir
 


### PR DESCRIPTION
When only one safetensors file and no model.safetensors.index.json file, three is a bug "index file is required for memory efficient saving" using save_hf_weight_memory_efficient. In this case, we add codes to generate self.index from the safetensors file.