### PR TITLE
feat: add load_weights_from_async_generator to Bridge

### DIFF
--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 import os
 from abc import ABC
-from typing import Callable, Generator
+from typing import AsyncGenerator, Callable, Generator
 from glob import glob
 from collections import defaultdict
 
@@ -260,6 +260,103 @@ class Bridge(ABC):
                     )
                 # load
                 param.copy_(param_to_load)
+
+    async def load_weights_from_async_generator(
+        self,
+        models: list[torch.nn.Module],
+        hf_weight_generator: AsyncGenerator[tuple[str, torch.Tensor], None],
+    ) -> None:
+        """
+        Load weights from a per-tensor generator into Megatron-Core models.
+        """
+        # Phase 1: build per-model mappings and a global reverse index.
+        if not hasattr(self, "_generator_per_model_meta"):
+            per_model_meta: list[tuple[dict, torch.nn.Module]] = []
+            for model in models:
+                local_to_global_map = self._weight_name_mapping_mcore_local_to_global(model)
+                local_to_hf_map = {
+                    k: self._weight_name_mapping_mcore_to_hf(v)
+                    for k, v in local_to_global_map.items()
+                    if "_extra_state" not in k
+                }
+                per_model_meta.append((local_to_hf_map, model))
+
+            hf_key_to_targets: dict[str, list[tuple[int, str]]] = defaultdict(list)
+            for model_idx, (local_to_hf_map, _) in enumerate(per_model_meta):
+                for local_name, hf_names in local_to_hf_map.items():
+                    for hf_key in hf_names:
+                        hf_key_to_targets[hf_key].append((model_idx, local_name))
+
+            self._generator_per_model_meta = per_model_meta
+            self._generator_hf_key_to_targets = hf_key_to_targets
+        else:
+            per_model_meta = self._generator_per_model_meta
+            hf_key_to_targets = self._generator_hf_key_to_targets
+
+        # Phase 2: flush helper (identical to the sync version)
+        def _flush(
+            model_idx: int,
+            local_name: str,
+            hf_names: list[str],
+            buffer: dict[str, torch.Tensor],
+        ) -> None:
+            """Convert buffered HF tensors → mcore format → slice own TP shard → copy."""
+            _, model = per_model_meta[model_idx]
+            param = model.state_dict()[local_name]
+
+            hf_weights = [buffer[x] for x in hf_names]
+            mcore_weight = self._weight_to_mcore_format(local_name, hf_weights)
+
+            # skip lm_head / embed_tokens for value models (shape[0] == 1)
+            if hf_names[0] in {
+                "lm_head.weight",
+                "model.embed_tokens.weight",
+                "model.language_model.embed_tokens.weight",
+            }:
+                if param.shape[0] == 1 and mcore_weight.shape[0] != 1:
+                    return
+
+            # Each rank independently slices its own shard — no communication needed.
+            if ".mlp.experts.linear_fc" in local_name:
+                shards = list(self._weight_split_across_tp(local_name, mcore_weight, param, self.mpu.etp_size))
+                shard = shards[self.mpu.etp_rank]
+            else:
+                shards = list(self._weight_split_across_tp(local_name, mcore_weight, param, self.mpu.tp_size))
+                shard = shards[self.mpu.tp_rank]
+
+            param.copy_(shard.to(param.device, dtype=param.dtype).contiguous())
+
+        # Phase 3: stream the async generator, buffer multi-key params
+        expected_hf_keys: set[str] = set(hf_key_to_targets.keys())
+        received_hf_keys: set[str] = set()
+        pending: dict[tuple[int, str], dict[str, torch.Tensor]] = defaultdict(dict)
+
+        async for hf_key, tensor in hf_weight_generator:
+            if hf_key in expected_hf_keys:
+                received_hf_keys.add(hf_key)
+
+            targets = hf_key_to_targets.get(hf_key)
+            if targets is None:
+                continue  # key not needed by this model — discard immediately
+
+            for model_idx, local_name in targets:
+                local_to_hf_map = per_model_meta[model_idx][0]
+                hf_names = local_to_hf_map[local_name]
+
+                slot = pending[(model_idx, local_name)]
+                slot[hf_key] = tensor.clone()
+
+                # flush as soon as every HF key for this param has arrived
+                if all(k in slot for k in hf_names):
+                    _flush(model_idx, local_name, hf_names, slot)
+                    del pending[(model_idx, local_name)]
+
+        missing_keys = expected_hf_keys - received_hf_keys
+        if missing_keys:
+            raise KeyError(
+                f"load_weights_from_async_generator: the following HuggingFace keys are "
+                f"required but were never yielded by the generator: {missing_keys}"
+            )
 
     def _save_weights_fast(
         self,


### PR DESCRIPTION
Sometimes we need to receive HF weights and load them into Megatron-Core models, this pr adds `Bridge.load_weights_from_async_generator`, which accepts an AsyncGenerator[tuple[str, torch.Tensor], None] and loads weights into Megatron-Core models on the fly.

