### PR TITLE
bugfix:Fix mbridge weight save logic

### DIFF
--- a/mbridge/core/safetensor_io.py
+++ b/mbridge/core/safetensor_io.py
@@ -145,8 +145,10 @@ class SafeTensorIO:
 
         filename_to_keys_map = self.get_keys_maps_to_save()
         states = {}
+        received_weight_keys = set()
         for hf_weight_name, tensor in per_tensor_generator:
             states[hf_weight_name] = tensor.cpu()
+            received_weight_keys.add(hf_weight_name)
             for filename, keys_for_file in filename_to_keys_map.items():
                 if keys_for_file.issubset(states.keys()):
                     to_save = {k: states[k] for k in keys_for_file}
@@ -154,7 +156,28 @@ class SafeTensorIO:
                     save_file(to_save, safetensor_file)
                     for k in keys_for_file:
                         del states[k]
-        if not set(states.keys()) == set(hf_shared_weight_keys):
+
+        # Fallback: group remaining states by filename from index and save them.
+        fallback_filename_to_states = defaultdict(dict)
+        for key in list(states.keys()):
+            filename = self.index.get(key)
+            if filename is not None:
+                fallback_filename_to_states[filename][key] = states[key]
+                del states[key]
+
+        for filename, to_save in fallback_filename_to_states.items():
+            safetensor_file = os.path.join(new_hf_dir, filename)
+            save_file(to_save, safetensor_file)
+
+        # Warn if some keys declared in original index are never provided by input.
+        missing_index_keys = set(self.index.keys()) - received_weight_keys
+        if missing_index_keys:
+            warnings.warn(
+                f"Some keys in original model.safetensors.index.json were not loaded: "
+                f"{sorted(missing_index_keys)}"
+            )
+
+        if states:
             warnings.warn(
                 f"Some weights are not saved: {states.keys()} {hf_shared_weight_keys=}"
             )


### PR DESCRIPTION
**Model Issue Type:** DeepSeek-like model with MTP modules
**Symptom:** Incomplete weight saving

**Root Cause Analysis:** The model contains MTP layers during inference, yet these layers become inactive and do not participate in reinforcement learning training. As a result, corresponding weights for the MTP layers are absent.However, the mbridge saving mode enforces strict key-value integrity verification for all entries inside the .safetensors file, requiring full exact matching.When MTP layers are excluded from training, weights of the 61st layer get lost, which further causes the final .safetensors file to fail saving completely.
**Solution Idea:** Check whether incomplete safetensors weights cause other model parameters to fail saving in the final fallback procedure.Ensure such remaining weights are saved normally. Meanwhile, output and log the missing weight keys in the safetensors file to prompt users.