### PR TITLE
[feat] Optimize export_weights with less comms and bucketed all-gather

### DIFF
--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -15,9 +15,10 @@ from safetensors import safe_open
 from .parallel_states import ParallelStates
 from .safetensor_io import SafeTensorIO
 from .util import (
-    broadcast_from_megatron_pp,
-    broadcast_str_from_megatron_pp,
+    bucketed_all_gather_into_tensor,
+    bucketed_pp_broadcast,
     get_model,
+    iter_model_named_params,
     unwrap_model,
 )
 
@@ -36,6 +37,7 @@ class Bridge(ABC):
         dtype: torch.dtype = torch.bfloat16,
         parallel_states: ParallelStates = None,
         make_vocab_size_divisible_by: int = None,
+        export_weights_buffer_max_size_bytes: int = 2 * 1024**3,
     ):
         """
         Initialize a bridge instance.
@@ -44,6 +46,7 @@ class Bridge(ABC):
             hf_config: Hugging Face model configuration
             dtype: Data type for model parameters
             parallel_states: Parallel processing states, or None to use default
+            export_weights_buffer_max_size_bytes: Max size of buffer for gather/broadcast in export weights
         """
         self.hf_config = hf_config
         self.extra_args = {}
@@ -64,6 +67,8 @@ class Bridge(ABC):
         # Some moe models require multiple weights to be combined into one,
         # such as qwen3vl. It will cache it into this buff until all weights are collected.
         self.export_weights_buff = {}
+        # 2GB max gather buffer size for export weights
+        self.export_weights_buffer_max_size_bytes = export_weights_buffer_max_size_bytes
 
     def get_model(
         self,
@@ -540,6 +545,285 @@ class Bridge(ABC):
         self.extra_args.update(kwargs)
         self.config = self._build_config()
 
+    def _get_collective_bucket_size_bytes(self, group_size: int) -> int:
+        if group_size <= 1:
+            return self.export_weights_buffer_max_size_bytes
+        return max(self.export_weights_buffer_max_size_bytes // group_size, 1)
+
+    def _iter_local_stage_named_params(
+        self, models: list[torch.nn.Module]
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        local_to_global_maps = [
+            self._weight_name_mapping_mcore_local_to_global(model, consider_ep=False)
+            for model in models
+        ]
+        for vpp_rank, name, param in iter_model_named_params(models):
+            yield local_to_global_maps[vpp_rank][name], param
+
+    def _iter_all_ranks_named_params(
+        self, models: list[torch.nn.Module], is_distributed: bool
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        """
+        Iterate over all named parameters of all models, and yield the name and parameter.
+        If using pp, all_gather the named parameters across all pp ranks.
+        """
+        if not is_distributed or self.mpu.pp_size <= 1:
+            yield from self._iter_local_stage_named_params(models)
+            return
+
+        local_named_params_list = list(self._iter_local_stage_named_params(models))
+        local_param_manifest = [
+            (
+                self.mpu.pp_rank,
+                name,
+                tuple(param.shape),
+                str(param.dtype).split(".", maxsplit=1)[1],
+                getattr(param, "tensor_model_parallel", None),
+                getattr(param, "partition_dim", None),
+                param.numel(),
+            )
+            for name, param in local_named_params_list
+        ]
+        param_manifest_all_pp = [None] * self.mpu.pp_size
+        torch.distributed.all_gather_object(
+            object_list=param_manifest_all_pp,
+            obj=local_param_manifest,
+            group=self.mpu.pp_group,
+        )
+        local_named_params = iter(local_named_params_list)
+        pp_bucket_limit_bytes = self.export_weights_buffer_max_size_bytes
+        element_size_cache: dict[str, int] = {}
+        for iter_pp_rank, stage_manifest in enumerate(param_manifest_all_pp):
+            pp_bucket: list[
+                tuple[
+                    str,
+                    tuple[int, ...],
+                    str,
+                    bool | None,
+                    int | None,
+                    int,
+                    torch.Tensor | None,
+                ]
+            ] = []
+            pp_bucket_bytes = 0
+
+            def _flush_pp_bucket():
+                nonlocal pp_bucket, pp_bucket_bytes
+                yield from bucketed_pp_broadcast(
+                    pp_bucket,
+                    src_pp_rank=iter_pp_rank,
+                    pp_group=self.mpu.pp_group,
+                    pp_rank=self.mpu.pp_rank,
+                    bucket_size_bytes=pp_bucket_limit_bytes,
+                )
+                pp_bucket = []
+                pp_bucket_bytes = 0
+
+            for (
+                manifest_pp_rank,
+                name,
+                shape,
+                dtype_name,
+                tensor_parallel,
+                partition_dim,
+                numel,
+            ) in stage_manifest:
+                assert manifest_pp_rank == iter_pp_rank
+                if dtype_name not in element_size_cache:
+                    element_size_cache[dtype_name] = torch.empty(
+                        (), dtype=getattr(torch, dtype_name)
+                    ).element_size()
+                param_bytes = numel * element_size_cache[dtype_name]
+                if iter_pp_rank == self.mpu.pp_rank:
+                    local_name, tensor = next(local_named_params)
+                    if local_name != name:
+                        raise RuntimeError(
+                            f"export parameter manifest mismatch: {local_name=} {name=}"
+                        )
+                else:
+                    tensor = None
+
+                should_flush = bool(pp_bucket) and (
+                    dtype_name != pp_bucket[0][2]
+                    or pp_bucket_bytes + param_bytes > pp_bucket_limit_bytes
+                )
+                if should_flush:
+                    yield from _flush_pp_bucket()
+
+                pp_bucket.append(
+                    (
+                        name,
+                        shape,
+                        dtype_name,
+                        tensor_parallel,
+                        partition_dim,
+                        numel,
+                        tensor,
+                    )
+                )
+                pp_bucket_bytes += param_bytes
+
+                if pp_bucket_bytes >= pp_bucket_limit_bytes:
+                    yield from _flush_pp_bucket()
+
+            yield from _flush_pp_bucket()
+
+    def _iter_merged_bucket_outputs(
+        self,
+        gathered_bucket: list[tuple[str, torch.Tensor, list[torch.Tensor]]] | None,
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        if gathered_bucket is None:
+            return
+        for i in range(len(gathered_bucket)):
+            bname, bparam, shards = gathered_bucket[i]
+            gathered_bucket[i] = None  # type: ignore[call-overload]
+            merged = self._weight_merge_across_tp(bname, shards, bparam)
+            del shards, bparam
+            for out_name, out_param in zip(*self._weight_to_hf_format(bname, merged)):
+                yield out_name, out_param.detach()
+            del merged
+
+    def _iter_bucketed_export_outputs(
+        self,
+        named_params: Generator[tuple[str, torch.Tensor], None, None],
+        collect_bucket_fn: Callable[
+            [list[tuple[str, torch.Tensor]], str],
+            list[tuple[str, torch.Tensor, list[torch.Tensor]]] | None,
+        ],
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        tp_bucket: list[tuple[str, torch.Tensor]] = []
+        tp_bucket_bytes = 0
+        ep_bucket: list[tuple[str, torch.Tensor]] = []
+        ep_bucket_bytes = 0
+        tp_bucket_limit_bytes = self._get_collective_bucket_size_bytes(self.mpu.tp_size)
+        ep_bucket_limit_bytes = self._get_collective_bucket_size_bytes(self.mpu.ep_size)
+        etp_bucket_limit_bytes = self._get_collective_bucket_size_bytes(
+            self.mpu.etp_size
+        )
+
+        def _should_flush_bucket(
+            bucket: list[tuple[str, torch.Tensor]],
+            bucket_bytes: int,
+            tensor: torch.Tensor,
+            bucket_limit_bytes: int,
+        ) -> bool:
+            if not bucket:
+                return False
+            return (
+                tensor.dtype != bucket[0][1].dtype
+                or bucket_bytes + tensor.nelement() * tensor.element_size() > bucket_limit_bytes
+            )
+
+        def _iter_etp_bucket_outputs(etp_bucket: list[tuple[str, torch.Tensor]]):
+            if not etp_bucket:
+                return
+
+            etp_subbucket: list[tuple[str, torch.Tensor]] = []
+            etp_subbucket_bytes = 0
+
+            def _flush_etp_subbucket():
+                nonlocal etp_subbucket, etp_subbucket_bytes
+                gathered_etp_bucket = collect_bucket_fn(etp_subbucket, "etp")
+                etp_subbucket = []
+                etp_subbucket_bytes = 0
+                yield from self._iter_merged_bucket_outputs(gathered_etp_bucket)
+
+            for i in range(len(etp_bucket)):
+                name, param = etp_bucket[i]
+                etp_bucket[i] = None  # type: ignore[call-overload]
+                param_bytes = param.nelement() * param.element_size()
+                if _should_flush_bucket(
+                    etp_subbucket,
+                    etp_subbucket_bytes,
+                    param,
+                    etp_bucket_limit_bytes,
+                ):
+                    yield from _flush_etp_subbucket()
+
+                etp_subbucket.append((name, param))
+                etp_subbucket_bytes += param_bytes
+                del param
+
+                if etp_subbucket_bytes >= etp_bucket_limit_bytes:
+                    yield from _flush_etp_subbucket()
+
+            yield from _flush_etp_subbucket()
+
+        def _flush_tp_bucket():
+            nonlocal tp_bucket, tp_bucket_bytes
+            gathered_bucket = collect_bucket_fn(tp_bucket, "tp")
+            tp_bucket = []
+            tp_bucket_bytes = 0
+            yield from self._iter_merged_bucket_outputs(gathered_bucket)
+
+        def _flush_ep_bucket():
+            nonlocal ep_bucket, ep_bucket_bytes
+            if not ep_bucket:
+                return
+            gathered_ep_bucket = collect_bucket_fn(ep_bucket, "ep")
+            ep_bucket = []
+            ep_bucket_bytes = 0
+            if not gathered_ep_bucket:
+                return
+
+            num_experts = self.config.num_moe_experts
+            num_experts_per_rank = num_experts // self.mpu.ep_size
+            etp_bucket: list[tuple[str, torch.Tensor]] = []
+            for i in range(len(gathered_ep_bucket)):
+                bname, _, ep_shards = gathered_ep_bucket[i]
+                gathered_ep_bucket[i] = None  # type: ignore[call-overload]
+                name_prefix, local_expert_id = bname.split(".weight")
+                local_expert_id = int(local_expert_id)
+                for ep_rank, expert_param in enumerate(ep_shards):
+                    global_expert_id = num_experts_per_rank * ep_rank + local_expert_id
+                    etp_bucket.append(
+                        (f"{name_prefix}.weight{global_expert_id}", expert_param)
+                    )
+                del ep_shards
+
+            yield from _iter_etp_bucket_outputs(etp_bucket)
+
+        for name, param in named_params:
+            param_bytes = param.nelement() * param.element_size()
+            is_ep_param = ".mlp.experts.linear_fc" in name
+            is_tp_param = (
+                hasattr(param, "tensor_model_parallel") and param.tensor_model_parallel
+            )
+
+            if is_ep_param:
+                # flush tp bucket first to keep logic simple, assuming ep params always appears together
+                yield from _flush_tp_bucket()
+                if _should_flush_bucket(
+                    ep_bucket, ep_bucket_bytes, param, ep_bucket_limit_bytes
+                ):
+                    yield from _flush_ep_bucket()
+                ep_bucket.append((name, param))
+                ep_bucket_bytes += param_bytes
+                if ep_bucket_bytes >= ep_bucket_limit_bytes:
+                    yield from _flush_ep_bucket()
+                continue
+
+            yield from _flush_ep_bucket()
+
+            if is_tp_param:
+                if _should_flush_bucket(
+                    tp_bucket, tp_bucket_bytes, param, tp_bucket_limit_bytes
+                ):
+                    yield from _flush_tp_bucket()
+                tp_bucket.append((name, param))
+                tp_bucket_bytes += param_bytes
+                if tp_bucket_bytes >= tp_bucket_limit_bytes:
+                    yield from _flush_tp_bucket()
+                continue
+
+            yield from _flush_tp_bucket()
+            for out_name, out_param in zip(*self._weight_to_hf_format(name, param)):
+                yield out_name, out_param.detach()
+
+        # last clean up
+        yield from _flush_ep_bucket()
+        yield from _flush_tp_bucket()
+
     @torch.no_grad()
     def export_weights(
         self, models: list[torch.nn.Module],
@@ -548,150 +832,32 @@ class Bridge(ABC):
             len(self.export_weights_buff) == 0
         ), f"should be empty {self.export_weights_buff=}"
         models = [unwrap_model(model) for model in models]
-
-        def get_model_chunk_generator():
-            for model in models:
-                existing_keys = set()
-                for name, param in model.named_parameters():
-                    existing_keys.add(name)
-                    yield name, param
-
-                # note
-                # there is a bug in megatron GPTModel
-                # decoder.layers[n].mlp.router.expert_bias" in GPTModel is not registered in named_parameter, but in state_dict().
-                # for now we patch it by adding those keys to extra_keys.
-                extra_keys = [
-                    x
-                    for x in model.state_dict().keys()
-                    if "_extra_state" not in x
-                    and "expert_bias" in x
-                    and x not in existing_keys
-                ]
-                for name in extra_keys:
-                    yield name, model.state_dict()[name].to(torch.cuda.current_device())
-
-        weights_names = []
-        for vpp_rank, model in enumerate(models):
-            existing_keys = set()
-            for name, param in model.named_parameters():
-                existing_keys.add(name)
-                weights_names.append((self.mpu.pp_rank, vpp_rank, name))
-            extra_keys = [
-                x
-                for x in model.state_dict().keys()
-                if "_extra_state" not in x
-                and "expert_bias" in x
-                and x not in existing_keys
-            ]
-            for name in extra_keys:
-                weights_names.append((self.mpu.pp_rank, vpp_rank, name))
-
-        weights_names_all_pp = [None] * self.mpu.pp_size
-        torch.distributed.all_gather_object(
-            object_list=weights_names_all_pp, obj=weights_names, group=self.mpu.pp_group
+        is_distributed = (
+            torch.distributed.is_available() and torch.distributed.is_initialized()
         )
-        weights_names_all_pp = sum(weights_names_all_pp, [])
-        model_chunk_generator = get_model_chunk_generator()
-        local_to_global_maps = [
-            self._weight_name_mapping_mcore_local_to_global(model, consider_ep=False)
-            for model in models
-        ]
-        for iter_pp_rank, iter_vpp_rank, iter_name in weights_names_all_pp:
-            local_to_global_map = local_to_global_maps[iter_vpp_rank]
-            if iter_pp_rank == self.mpu.pp_rank:
-                try:
-                    name, param = next(model_chunk_generator)
-                except StopIteration:
-                    name, param = None, None
-                name = local_to_global_map[iter_name]
-            else:
-                name, param = None, None
 
-            name = broadcast_str_from_megatron_pp(name)
-            broad_pp_param = broadcast_from_megatron_pp(param)
+        groups_by_mode = {
+            "tp": (self.mpu.tp_group, self.mpu.tp_size),
+            "ep": (self.mpu.ep_group, self.mpu.ep_size),
+            "etp": (self.mpu.etp_group, self.mpu.etp_size),
+        }
 
-            # EP
-            if ".mlp.experts.linear_fc" in name:
-                num_experts = self.config.num_moe_experts
-                num_experts_per_rank = num_experts // self.mpu.ep_size
-
-                if self.mpu.ep_size > 1:
-                    infer_params = [
-                        torch.empty_like(broad_pp_param) for _ in range(self.mpu.ep_size)
-                    ]
-                    torch.distributed.all_gather(
-                        infer_params, broad_pp_param, group=self.mpu.ep_group
-                    )
-                else:
-                    infer_params = [broad_pp_param]
-
-                name_prefix, local_expert_id = name.split(".weight")
-                local_expert_id = int(local_expert_id)
-                global_expert_ids = [
-                    num_experts_per_rank * ep_rank + local_expert_id
-                    for ep_rank in range(self.mpu.ep_size)
-                ]
-                global_expert_names = [
-                    f"{name_prefix}.weight{expert_id}"
-                    for expert_id in global_expert_ids
-                ]
-
-                for name, param in zip(global_expert_names, infer_params):
-                    if self.mpu.etp_size > 1:
-                        # gather etp
-                        etp_params = [
-                            torch.empty_like(param) for _ in range(self.mpu.etp_size)
-                        ]
-                        torch.distributed.all_gather(
-                            etp_params, param, group=self.mpu.etp_group
-                        )
-                        params = etp_params
-                    else:
-                        params = [param]
-
-                    merge_params = self._weight_merge_across_tp(
-                        name, params, broad_pp_param
-                    )
-                    converted_names, converted_params = self._weight_to_hf_format(
-                        name, merge_params
-                    )
-                    # Some moe models require multiple weights to be merge into one, such as qwen3vl
-                    if len(converted_names) == 0:
-                        continue
-
-                    yield from zip(converted_names, [p.detach() for p in converted_params])
-                continue
-
-            # TP
-            if (
-                hasattr(broad_pp_param, "tensor_model_parallel")
-                and broad_pp_param.tensor_model_parallel
-            ):
-                # allocate a new tensor with proper size
-                if self.mpu.tp_size <= 1:
-                    infer_params = [broad_pp_param]
-                else:
-                    infer_params = [
-                        torch.empty_like(broad_pp_param)
-                        for _ in range(self.mpu.tp_size)
-                    ]
-                    torch.distributed.all_gather(
-                        infer_params, broad_pp_param, group=self.mpu.tp_group
-                    )
-                infer_params = self._weight_merge_across_tp(
-                    name, infer_params, broad_pp_param
-                )
-            else:
-                infer_params = broad_pp_param
-
-            converted_names, converted_params = self._weight_to_hf_format(
-                name, infer_params
+        def _collect_bucket(bucket: list[tuple[str, torch.Tensor]], parallel_mode: str):
+            if parallel_mode not in groups_by_mode:
+                raise ValueError(f"Unsupported parallel_mode: {parallel_mode}")
+            group, group_size = groups_by_mode[parallel_mode]
+            return bucketed_all_gather_into_tensor(
+                bucket,
+                group=group,
+                group_size=group_size,
+                per_rank_bucket_size_bytes=self._get_collective_bucket_size_bytes(
+                    group_size
+                ),
             )
-            # Some moe models require multiple weights to be merge into one, such as qwen3vl
-            if len(converted_names) == 0:
-                continue
-
-            yield from zip(converted_names, [p.detach() for p in converted_params])
+        # broadcast inside pp group
+        named_params = self._iter_all_ranks_named_params(models, is_distributed)
+        # allgather inside tp/ep/etp groups
+        yield from self._iter_bucketed_export_outputs(named_params, _collect_bucket)
 
     def export_weights_without_gather(
         self, models: list[torch.nn.Module],

--- a/mbridge/core/util.py
+++ b/mbridge/core/util.py
@@ -5,6 +5,7 @@ import json
 import os
 from collections import defaultdict
 from functools import lru_cache
+from typing import Generator
 
 import torch
 from megatron.core import mpu
@@ -757,3 +758,212 @@ def postprocess_packed_seqs(
         output_new[i, attention_mask[i]] = tmp[:s_len]
 
     return output_new
+
+
+def iter_model_named_params(
+    models: list[torch.nn.Module],
+) -> Generator[tuple[int, str, torch.Tensor], None, None]:
+    for vpp_rank, model in enumerate(models):
+        existing_keys: set[str] = set()
+        for name, param in model.named_parameters():
+            existing_keys.add(name)
+            yield vpp_rank, name, param
+
+        state_dict = model.state_dict()
+        extra_keys = [
+            x
+            for x in state_dict.keys()
+            if "_extra_state" not in x
+            and "expert_bias" in x
+            and x not in existing_keys
+        ]
+        for name in extra_keys:
+            yield vpp_rank, name, state_dict[name].to(torch.cuda.current_device())
+
+
+def bucketed_all_gather_into_tensor(
+    bucket: list[tuple[str, torch.Tensor]],
+    group: "torch.distributed.ProcessGroup",
+    group_size: int,
+    per_rank_bucket_size_bytes: int,
+) -> list[tuple[str, torch.Tensor, list[torch.Tensor]]]:
+    if not bucket:
+        return []
+
+    if group_size <= 1:
+        return [(name, param, [param]) for name, param in bucket]
+
+    dtype = bucket[0][1].dtype
+    device = bucket[0][1].device
+    if any(param.dtype != dtype for _, param in bucket):
+        raise ValueError("bucket tensors must share the same dtype")
+
+    max_chunk_numel = max(
+        1, per_rank_bucket_size_bytes // bucket[0][1].element_size()
+    )
+
+    flat_shards = [param.reshape(-1) for _, param in bucket]
+    numel_per_tensor = [flat.numel() for flat in flat_shards]
+    gathered_shards_by_rank = [
+        [torch.empty_like(param) for _, param in bucket] for _ in range(group_size)
+    ]
+    gathered_flat_views = [
+        [tensor.view(-1) for tensor in rank_shards]
+        for rank_shards in gathered_shards_by_rank
+    ]
+
+    # NOTE: Using `all_gather_into_tensor` with a single flat recv buffer
+    # avoids ProcessGroupNCCL::allgather's unconditional `newLikeFlat`
+    # temporary allocation that the list-form `all_gather` would trigger.
+    send_buffer = torch.empty(max_chunk_numel, dtype=dtype, device=device)
+    recv_buffer = torch.empty(
+        group_size * max_chunk_numel, dtype=dtype, device=device
+    )
+
+    tensor_idx = 0
+    tensor_offset = 0
+    while tensor_idx < len(bucket):
+        chunk_segments = []
+        chunk_numel = 0
+        while tensor_idx < len(bucket) and chunk_numel < max_chunk_numel:
+            available = numel_per_tensor[tensor_idx] - tensor_offset
+            take_numel = min(available, max_chunk_numel - chunk_numel)
+            send_buffer[chunk_numel : chunk_numel + take_numel].copy_(
+                flat_shards[tensor_idx][tensor_offset : tensor_offset + take_numel]
+            )
+            chunk_segments.append(
+                (tensor_idx, tensor_offset, chunk_numel, take_numel)
+            )
+            chunk_numel += take_numel
+            tensor_offset += take_numel
+            if tensor_offset == numel_per_tensor[tensor_idx]:
+                tensor_idx += 1
+                tensor_offset = 0
+
+        recv_view = recv_buffer[: group_size * chunk_numel]
+        torch.distributed.all_gather_into_tensor(
+            recv_view,
+            send_buffer[:chunk_numel],
+            group=group,
+        )
+
+        for rank in range(group_size):
+            rank_recv_view = recv_view[
+                rank * chunk_numel : (rank + 1) * chunk_numel
+            ]
+            for (
+                seg_tensor_idx,
+                seg_tensor_offset,
+                seg_chunk_offset,
+                seg_numel,
+            ) in chunk_segments:
+                gathered_flat_views[rank][seg_tensor_idx][
+                    seg_tensor_offset : seg_tensor_offset + seg_numel
+                ].copy_(
+                    rank_recv_view[seg_chunk_offset : seg_chunk_offset + seg_numel]
+                )
+
+    del send_buffer, recv_buffer
+
+    gathered_bucket = []
+    for idx, (name, param) in enumerate(bucket):
+        shards = [gathered_shards_by_rank[rank][idx] for rank in range(group_size)]
+        gathered_bucket.append((name, param, shards))
+    return gathered_bucket
+
+
+def bucketed_pp_broadcast(
+    bucket: list[
+        tuple[
+            str,             # name 
+            tuple[int, ...], # shape
+            str,             # dtype_name
+            bool | None,     # tensor_parallel
+            int | None,      # partition_dim
+            int,             # numel
+            torch.Tensor | None, # tensor
+        ]
+    ],
+    src_pp_rank: int,
+    pp_group: "torch.distributed.ProcessGroup",
+    pp_rank: int,
+    bucket_size_bytes: int,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    if not bucket:
+        return
+
+    dtype = getattr(torch, bucket[0][2])
+    element_size = torch.empty((), dtype=dtype).element_size()
+    max_chunk_numel = max(1, bucket_size_bytes // element_size)
+    src_global_rank = torch.distributed.get_global_rank(
+        group=pp_group, group_rank=src_pp_rank
+    )
+
+    if pp_rank == src_pp_rank:
+        output_tensors = [tensor for _, _, _, _, _, _, tensor in bucket]
+        if any(tensor is None for tensor in output_tensors):
+            raise RuntimeError("source pp bucket is missing local tensors")
+        flat_views = [tensor.reshape(-1) for tensor in output_tensors]
+    else:
+        output_tensors = []
+        flat_views = []
+        for _, shape, _, tensor_parallel, partition_dim, _, _ in bucket:
+            tensor = torch.empty(
+                size=shape,
+                dtype=dtype,
+                device=torch.cuda.current_device(),
+            )
+            if tensor_parallel is not None:
+                tensor.tensor_model_parallel = tensor_parallel
+            if partition_dim is not None:
+                tensor.partition_dim = partition_dim
+            output_tensors.append(tensor)
+            flat_views.append(tensor.view(-1))
+
+    buffer = torch.empty(
+        max_chunk_numel, dtype=dtype, device=torch.cuda.current_device()
+    )
+    tensor_idx = 0
+    tensor_offset = 0
+    while tensor_idx < len(bucket):
+        chunk_segments = []
+        chunk_numel = 0
+        while tensor_idx < len(bucket) and chunk_numel < max_chunk_numel:
+            available = bucket[tensor_idx][5] - tensor_offset
+            take_numel = min(available, max_chunk_numel - chunk_numel)
+            if pp_rank == src_pp_rank:
+                buffer[chunk_numel : chunk_numel + take_numel].copy_(
+                    flat_views[tensor_idx][tensor_offset : tensor_offset + take_numel]
+                )
+            chunk_segments.append(
+                (tensor_idx, tensor_offset, chunk_numel, take_numel)
+            )
+            chunk_numel += take_numel
+            tensor_offset += take_numel
+            if tensor_offset == bucket[tensor_idx][5]:
+                tensor_idx += 1
+                tensor_offset = 0
+
+        chunk_view = buffer[:chunk_numel]
+        torch.distributed.broadcast(
+            tensor=chunk_view,
+            src=src_global_rank,
+            group=pp_group,
+        )
+
+        if pp_rank == src_pp_rank:
+            continue
+
+        for seg_tensor_idx, seg_tensor_offset, seg_chunk_offset, seg_numel in chunk_segments:
+            flat_views[seg_tensor_idx][
+                seg_tensor_offset : seg_tensor_offset + seg_numel
+            ].copy_(chunk_view[seg_chunk_offset : seg_chunk_offset + seg_numel])
+
+    del buffer
+    del flat_views
+
+    for i in range(len(bucket)):
+        name = bucket[i][0]
+        tensor = output_tensors[i]
+        output_tensors[i] = None
+        yield name, tensor


### PR DESCRIPTION
# What does this PR do?
Legacy `export_weights` is inefficient due to:

1. redundant broadcast and all-gathe
<img width="2376" height="1260" alt="image" src="https://github.com/user-attachments/assets/52fb1ea0-68f3-43dd-9497-a93c90df6429" />

2. frequent small-tensor all-gather

This pr removes redundant communication ops and uses a larger bucket to send and receive tensors.

# Experiment
4x speed-up using Qwen3-30B-A3B, 32GPUs, TP4EP2PP4 in megatron, colocated trainer and rollouter
<img width="874" height="166" alt="image" src="https://github.com/user-attachments/assets/28a15474-f3f7-44c6-b0fc-622a368026f9" />
