### PR TITLE
adapt to new mcore for qwen35 mtp

### DIFF
--- a/mbridge/models/qwen3_5/base_bridge.py
+++ b/mbridge/models/qwen3_5/base_bridge.py
@@ -298,6 +298,13 @@ class Qwen3_5VlBaseBridge(VLMBridge):
     def _convert_mtp_param(self, name: str) -> list[str]:
         assert self.config.mtp_num_layers == 1, "only support one mtp layer for now"
 
+        # Normalize: new megatron versions use "mtp_model_layer", old ones use "transformer_layer".
+        # Canonicalize to "transformer_layer" so a single _MTP_MAPPING covers both.
+        name = name.replace(
+            "language_model.mtp.layers.0.mtp_model_layer.",
+            "language_model.mtp.layers.0.transformer_layer.",
+        )
+
         # Handle MoE expert weights: extract expert_index from the suffix
         # e.g. language_model.mtp.layers.0.transformer_layer.mlp.experts.linear_fc1.weight3
         #   -> key = "...linear_fc1.weight{expert_index}", expert_index = 3

--- a/mbridge/models/qwen3_5/model.py
+++ b/mbridge/models/qwen3_5/model.py
@@ -156,8 +156,11 @@ class Qwen3_5VLModel(MegatronModule):
 
         if language_mtp_block_spec is not None:
             for _, layer_spec in enumerate(language_mtp_block_spec.layer_specs):
-                if issubclass(layer_spec.submodules.transformer_layer.submodules.self_attention.module, SelfAttention):
-                    layer_spec.submodules.transformer_layer.submodules.self_attention.module = Qwen3_5VLSelfAttention
+                # 'mtp_model_layer' is the new name in megatron (renamed from 'transformer_layer')
+                mtp_inner = getattr(layer_spec.submodules, 'mtp_model_layer', None) or getattr(layer_spec.submodules, 'transformer_layer', None)
+                if mtp_inner is not None and issubclass(mtp_inner.submodules.self_attention.module, SelfAttention):
+                    mtp_inner.submodules.self_attention.module = Qwen3_5VLSelfAttention
+
 
         self.pre_process = pre_process
         self.post_process = post_process


### PR DESCRIPTION
in newest mcore, 'transformer_layer' in mtp is renamed as 'mtp_model_layer'