### PR TITLE
[feat] Add option to export split experts for models using the new hf moe format

### DIFF
--- a/mbridge/core/auto_bridge.py
+++ b/mbridge/core/auto_bridge.py
@@ -117,7 +117,9 @@ class AutoBridge:
             "Use from_pretrained() or from_config() class methods instead."
         )
 
-    def export_weights(self, models: list) -> None:
+    def export_weights(
+        self, models: list, keep_stacked_experts: bool = True
+    ) -> None:
         """
         This is a placeholder implementation. AutoBridge doesn't implement this method directly
         as it delegates to specific bridge classes.

--- a/mbridge/core/auto_bridge.py
+++ b/mbridge/core/auto_bridge.py
@@ -117,9 +117,7 @@ class AutoBridge:
             "Use from_pretrained() or from_config() class methods instead."
         )
 
-    def export_weights(
-        self, models: list, keep_stacked_experts: bool = True
-    ) -> None:
+    def export_weights(self, models: list, keep_stacked_experts: bool = True) -> None:
         """
         This is a placeholder implementation. AutoBridge doesn't implement this method directly
         as it delegates to specific bridge classes.

--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -478,7 +478,9 @@ class Bridge(ABC):
                         tmp_w_name, params, params[0]
                     )
                     for hf_name, hf_param in zip(
-                        *self._weight_to_hf_format(tmp_w_name, infer_params)
+                        *self._weight_to_hf_format(
+                            tmp_w_name, infer_params, keep_stacked_experts=True
+                        )
                     ):
                         hf_buffer[hf_name] = hf_param.detach().cpu()
                         if len(hf_buffer) >= tensors_per_file:
@@ -496,7 +498,9 @@ class Bridge(ABC):
                 else:
                     infer_params = load_tensor_from_file(w_files[0])
                 for hf_name, hf_param in zip(
-                    *self._weight_to_hf_format(w_name, infer_params)
+                    *self._weight_to_hf_format(
+                        w_name, infer_params, keep_stacked_experts=True
+                    )
                 ):
                     hf_buffer[hf_name] = hf_param.detach().cpu()
                     if len(hf_buffer) >= tensors_per_file:
@@ -566,7 +570,7 @@ class Bridge(ABC):
             return self._save_weights_fast(models, weights_path, strict=strict)
 
         rank = torch.distributed.get_rank() if is_distributed else 0
-        per_tensor_generator = self.export_weights(models)
+        per_tensor_generator = self.export_weights(models, keep_stacked_experts=True)
 
         if rank != 0:
             for _, _ in per_tensor_generator:
@@ -723,6 +727,7 @@ class Bridge(ABC):
     def _iter_merged_bucket_outputs(
         self,
         gathered_bucket: list[tuple[str, torch.Tensor, list[torch.Tensor]]] | None,
+        keep_stacked_experts: bool = True,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         if gathered_bucket is None:
             return
@@ -731,7 +736,11 @@ class Bridge(ABC):
             gathered_bucket[i] = None  # type: ignore[call-overload]
             merged = self._weight_merge_across_tp(bname, shards, bparam)
             del shards, bparam
-            for out_name, out_param in zip(*self._weight_to_hf_format(bname, merged)):
+            for out_name, out_param in zip(
+                *self._weight_to_hf_format(
+                    bname, merged, keep_stacked_experts=keep_stacked_experts
+                )
+            ):
                 yield out_name, out_param.detach()
             del merged
 
@@ -742,6 +751,7 @@ class Bridge(ABC):
             [list[tuple[str, torch.Tensor]], str],
             list[tuple[str, torch.Tensor, list[torch.Tensor]]] | None,
         ],
+        keep_stacked_experts: bool = True,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         tp_bucket: list[tuple[str, torch.Tensor]] = []
         tp_bucket_bytes = 0
@@ -779,7 +789,10 @@ class Bridge(ABC):
                 gathered_etp_bucket = collect_bucket_fn(etp_subbucket, "etp")
                 etp_subbucket = []
                 etp_subbucket_bytes = 0
-                yield from self._iter_merged_bucket_outputs(gathered_etp_bucket)
+                yield from self._iter_merged_bucket_outputs(
+                    gathered_etp_bucket,
+                    keep_stacked_experts=keep_stacked_experts,
+                )
 
             for i in range(len(etp_bucket)):
                 name, param = etp_bucket[i]
@@ -807,7 +820,10 @@ class Bridge(ABC):
             gathered_bucket = collect_bucket_fn(tp_bucket, "tp")
             tp_bucket = []
             tp_bucket_bytes = 0
-            yield from self._iter_merged_bucket_outputs(gathered_bucket)
+            yield from self._iter_merged_bucket_outputs(
+                gathered_bucket,
+                keep_stacked_experts=keep_stacked_experts,
+            )
 
         def _flush_ep_bucket():
             nonlocal ep_bucket, ep_bucket_bytes
@@ -870,7 +886,11 @@ class Bridge(ABC):
                 continue
 
             yield from _flush_tp_bucket()
-            for out_name, out_param in zip(*self._weight_to_hf_format(name, param)):
+            for out_name, out_param in zip(
+                *self._weight_to_hf_format(
+                    name, param, keep_stacked_experts=keep_stacked_experts
+                )
+            ):
                 yield out_name, out_param.detach()
 
         # last clean up
@@ -881,6 +901,7 @@ class Bridge(ABC):
     def export_weights(
         self,
         models: list[torch.nn.Module],
+        keep_stacked_experts: bool = True,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         assert (
             len(self.export_weights_buff) == 0
@@ -912,7 +933,11 @@ class Bridge(ABC):
         # broadcast inside pp group
         named_params = self._iter_all_ranks_named_params(models, is_distributed)
         # allgather inside tp/ep/etp groups
-        yield from self._iter_bucketed_export_outputs(named_params, _collect_bucket)
+        yield from self._iter_bucketed_export_outputs(
+            named_params,
+            _collect_bucket,
+            keep_stacked_experts=keep_stacked_experts,
+        )
 
     def export_weights_without_gather(
         self,
@@ -1274,7 +1299,10 @@ class Bridge(ABC):
             return self._weight_name_mapping_other(mcore_weights_name)
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -1285,6 +1313,12 @@ class Bridge(ABC):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: If True (default), MoE expert weights are buffered
+                and stacked into a single ``[num_experts, ...]`` tensor matching the
+                official HF fused layout. If False, each expert is yielded
+                individually with a per-expert HF key. Only relevant for MoE
+                bridges that override this method; non-MoE overrides simply
+                accept the kwarg for signature compatibility.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors

--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -903,6 +903,16 @@ class Bridge(ABC):
         models: list[torch.nn.Module],
         keep_stacked_experts: bool = True,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        """
+        Export weights from models.
+
+        Args:
+            models: List of models to export weights from
+            keep_stacked_experts: If True (default), keep hf format of stacked experts; else emit each expert as its own hf key, yet keep gate_up_proj fused
+
+        Returns:
+            Generator[tuple[str, torch.Tensor]]: Generator of (name, tensor) tuples.
+        """
         assert (
             len(self.export_weights_buff) == 0
         ), f"should be empty {self.export_weights_buff=}"

--- a/mbridge/models/deepseek_v3.py
+++ b/mbridge/models/deepseek_v3.py
@@ -313,7 +313,10 @@ class DeepseekV3Bridge(LLMBridge):
             )
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
 
         # note: only support one mtp layer for now
@@ -324,7 +327,11 @@ class DeepseekV3Bridge(LLMBridge):
         ):
             hf_names = self._SHARED_STATE_DICT_MAPPING[mcore_weights_name]
             return hf_names, [mcore_weights] * len(hf_names)
-        return super()._weight_to_hf_format(mcore_weights_name, mcore_weights)
+        return super()._weight_to_hf_format(
+            mcore_weights_name,
+            mcore_weights,
+            keep_stacked_experts=keep_stacked_experts,
+        )
 
     def _get_safetensor_io(self, weights_path: str):
         if self.dtype == torch.bfloat16:

--- a/mbridge/models/gemma3/__init__.py
+++ b/mbridge/models/gemma3/__init__.py
@@ -195,7 +195,10 @@ class Gemma3Bridge(VLMBridge):
         return convert_names
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -206,6 +209,9 @@ class Gemma3Bridge(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: Accepted for signature compatibility with the base
+                class. This bridge has no MoE expert fusing, so the parameter is
+                otherwise unused.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors

--- a/mbridge/models/glm4_vl/base_bridge.py
+++ b/mbridge/models/glm4_vl/base_bridge.py
@@ -123,7 +123,10 @@ class Glm4VLBridgeBase(VLMBridge):
         return convert_names
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -134,6 +137,9 @@ class Glm4VLBridgeBase(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: Accepted for signature compatibility with the base
+                class. This bridge has no MoE expert fusing, so the parameter is
+                otherwise unused.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors

--- a/mbridge/models/internvl3/__init__.py
+++ b/mbridge/models/internvl3/__init__.py
@@ -200,7 +200,10 @@ class InternVL3Bridge(VLMBridge):
         return convert_names
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -211,6 +214,9 @@ class InternVL3Bridge(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: Accepted for signature compatibility with the base
+                class. This bridge has no MoE expert fusing, so the parameter is
+                otherwise unused.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors

--- a/mbridge/models/mimo.py
+++ b/mbridge/models/mimo.py
@@ -142,10 +142,17 @@ class MimoBridge(Qwen2Bridge):
         return weight
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """Swap halves back when exporting eh_proj weights to HuggingFace format."""
         if mcore_weights_name.endswith("eh_proj.weight"):
             first_half, second_half = mcore_weights.chunk(2, dim=1)
             mcore_weights = torch.cat([second_half, first_half], dim=1)
-        return super()._weight_to_hf_format(mcore_weights_name, mcore_weights)
+        return super()._weight_to_hf_format(
+            mcore_weights_name,
+            mcore_weights,
+            keep_stacked_experts=keep_stacked_experts,
+        )

--- a/mbridge/models/qwen2_5_vl/__init__.py
+++ b/mbridge/models/qwen2_5_vl/__init__.py
@@ -207,7 +207,10 @@ class Qwen2_5VLBridge(VLMBridge):
         return convert_names
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -218,6 +221,9 @@ class Qwen2_5VLBridge(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: Accepted for signature compatibility with the base
+                class. This bridge has no MoE expert fusing, so the parameter is
+                otherwise unused.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors

--- a/mbridge/models/qwen3_5/base_bridge.py
+++ b/mbridge/models/qwen3_5/base_bridge.py
@@ -362,7 +362,10 @@ class Qwen3_5VlBaseBridge(VLMBridge):
             )
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = False, # it is default to False now
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -373,6 +376,10 @@ class Qwen3_5VlBaseBridge(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: If True, buffer per-expert MoE weights and emit a single fused
+                tensor (shape `[num_experts, ...]`) keyed by the HF fused name. If False
+                (default), emit each expert as a separate HF key
+                ``...mlp.experts.{expert_id}.{fused_proj_name}.weight``.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors
@@ -400,10 +407,21 @@ class Qwen3_5VlBaseBridge(VLMBridge):
 
             # moe
             if ".mlp.experts.linear_fc" in mcore_weights_name:
-                # get export index
-                experts_key = hf_names[0]
                 experts_idx = int(mcore_weights_name.split(".weight")[-1])
+                if not keep_stacked_experts:
+                    # Emit per-expert HF key, e.g.
+                    #   model.language_model.layers.{N}.mlp.experts.gate_up_proj
+                    # becomes
+                    #   model.language_model.layers.{N}.mlp.experts.{expert_id}.gate_up_proj.weight
+                    fused_name = hf_names[0]
+                    prefix, _, proj_name = fused_name.rpartition(".")
+                    assert prefix.endswith(".experts"), (
+                        f"unexpected fused experts key: {fused_name}"
+                    )
+                    per_expert_name = f"{prefix}.{experts_idx}.{proj_name}.weight"
+                    return [per_expert_name], [mcore_weights]
 
+                experts_key = hf_names[0]
                 if experts_key not in self.export_weights_buff:
                     self.export_weights_buff[experts_key] = {}
                 assert experts_idx not in self.export_weights_buff[experts_key]

--- a/mbridge/models/qwen3_5/base_bridge.py
+++ b/mbridge/models/qwen3_5/base_bridge.py
@@ -416,9 +416,9 @@ class Qwen3_5VlBaseBridge(VLMBridge):
                     #   model.language_model.layers.{N}.mlp.experts.{expert_id}.gate_up_proj.weight
                     fused_name = hf_names[0]
                     prefix, _, proj_name = fused_name.rpartition(".")
-                    assert prefix.endswith(".experts"), (
-                        f"unexpected fused experts key: {fused_name}"
-                    )
+                    assert prefix.endswith(
+                        ".experts"
+                    ), f"unexpected fused experts key: {fused_name}"
                     per_expert_name = f"{prefix}.{experts_idx}.{proj_name}.weight"
                     return [per_expert_name], [mcore_weights]
 

--- a/mbridge/models/qwen3_5/base_bridge.py
+++ b/mbridge/models/qwen3_5/base_bridge.py
@@ -365,7 +365,7 @@ class Qwen3_5VlBaseBridge(VLMBridge):
         self,
         mcore_weights_name: str,
         mcore_weights: torch.Tensor,
-        keep_stacked_experts: bool = False, # it is default to False now
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -376,9 +376,10 @@ class Qwen3_5VlBaseBridge(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
-            keep_stacked_experts: If True, buffer per-expert MoE weights and emit a single fused
-                tensor (shape `[num_experts, ...]`) keyed by the HF fused name. If False
-                (default), emit each expert as a separate HF key
+            keep_stacked_experts: If True (default), buffer per-expert MoE weights and emit a
+                single fused tensor (shape ``[num_experts, ...]``) keyed by the HF fused name,
+                matching the official HF checkpoint layout. If False, emit each expert as a
+                separate HF key
                 ``...mlp.experts.{expert_id}.{fused_proj_name}.weight``.
 
         Returns:

--- a/mbridge/models/qwen3_omni_moe/base_bridge.py
+++ b/mbridge/models/qwen3_omni_moe/base_bridge.py
@@ -135,7 +135,10 @@ class Qwen3OmniBaseBridge(VLMBridge):
         return convert_names
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -146,6 +149,9 @@ class Qwen3OmniBaseBridge(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: Accepted for signature compatibility with the base
+                class. This bridge does not currently differentiate behavior; the
+                parameter is forwarded but otherwise unused.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors

--- a/mbridge/models/qwen3_vl/base_bridge.py
+++ b/mbridge/models/qwen3_vl/base_bridge.py
@@ -126,7 +126,10 @@ class Qwen3VBaseBridge(VLMBridge):
         return convert_names
 
     def _weight_to_hf_format(
-        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+        self,
+        mcore_weights_name: str,
+        mcore_weights: torch.Tensor,
+        keep_stacked_experts: bool = True,
     ) -> tuple[list[str], list[torch.Tensor]]:
         """
         Export MCore weights to Hugging Face format.
@@ -137,6 +140,11 @@ class Qwen3VBaseBridge(VLMBridge):
         Args:
             mcore_weights_name: MCore weight name
             mcore_weights: MCore weight tensor
+            keep_stacked_experts: If True (default), buffer per-expert MoE weights and emit a
+                single fused tensor (shape ``[num_experts, ...]``) keyed by the HF fused name,
+                matching the official HF checkpoint layout. If False, emit each expert as a
+                separate HF key
+                ``...mlp.experts.{expert_id}.{fused_proj_name}.weight``.
 
         Returns:
             tuple: (hf_names, hf_weights) - lists of Hugging Face weight names and tensors
@@ -182,6 +190,22 @@ class Qwen3VBaseBridge(VLMBridge):
                 # get export index
                 experts_key = hf_names[0]
                 experts_idx = int(mcore_weights_name.split(".weight")[-1])
+
+                if not keep_stacked_experts:
+                    # Emit per-expert HF key, e.g.
+                    #   model.language_model.layers.{N}.mlp.experts.gate_up_proj
+                    # becomes
+                    #   model.language_model.layers.{N}.mlp.experts.{expert_id}.gate_up_proj.weight
+                    # Per-expert tensors keep the same ``.T`` layout used in the
+                    # fused path so a downstream concatenation along dim 0 would
+                    # reproduce the fused tensor.
+                    fused_name = experts_key
+                    prefix, _, proj_name = fused_name.rpartition(".")
+                    assert prefix.endswith(".experts"), (
+                        f"unexpected fused experts key: {fused_name}"
+                    )
+                    per_expert_name = f"{prefix}.{experts_idx}.{proj_name}.weight"
+                    return [per_expert_name], [mcore_weights.T]
 
                 if experts_key not in self.export_weights_buff:
                     self.export_weights_buff[experts_key] = {}

--- a/mbridge/models/qwen3_vl/base_bridge.py
+++ b/mbridge/models/qwen3_vl/base_bridge.py
@@ -201,9 +201,9 @@ class Qwen3VBaseBridge(VLMBridge):
                     # reproduce the fused tensor.
                     fused_name = experts_key
                     prefix, _, proj_name = fused_name.rpartition(".")
-                    assert prefix.endswith(".experts"), (
-                        f"unexpected fused experts key: {fused_name}"
-                    )
+                    assert prefix.endswith(
+                        ".experts"
+                    ), f"unexpected fused experts key: {fused_name}"
                     per_expert_name = f"{prefix}.{experts_idx}.{proj_name}.weight"
                     return [per_expert_name], [mcore_weights.T]
 


### PR DESCRIPTION
## Background

Qwen3.5 MoE models store all experts of one layer in a single fused HF tensor, e.g.

    model.language_model.layers.{N}.mlp.experts.gate_up_proj
        # shape: [num_experts, 2*intermediate, hidden]

This leads to a very high memory peak when 

## What this PR does

Adds a `keep_stacked_experts: bool = True` kwarg to `export_weights`,
propagated through `_weight_to_hf_format` on all bridges. This argument only
works on models like Qwen3.5.

- **`True` (default)**: unchanged behavior — emit one fused tensor per
  layer matching the official HF layout.
- **`False`**: emit each expert as its own HF key, keeping gate and up
  fused together within each expert:

        model.language_model.layers.{N}.mlp.experts.{expert_id}.gate_up_proj.weight
            # shape: [2*intermediate, hidden]   (one per expert)

  Stacking these N tensors along dim 0 reproduces the original fused tensor.

`save_weights` always forces `keep_stacked_experts=True` so on-disk
safetensors keep matching `model.safetensors.index.json`.