### PR TITLE
fix: get_hf_rope_scaling for qwen2_5_vl

### DIFF
--- a/example/glm4v/_test_mrope_hf_vs_megatron.py
+++ b/example/glm4v/_test_mrope_hf_vs_megatron.py
@@ -23,7 +23,7 @@ from transformers.models.glm4v.modeling_glm4v import (
 
 from mbridge import AutoBridge
 from mbridge.models.glm4_vl.vl_mixin import VLMixin
-from mbridge.utils.hf_config import get_hf_rope_theta
+from mbridge.utils.hf_config import get_hf_rope_theta, get_hf_rope_scaling
 
 messages = [
     {
@@ -60,7 +60,7 @@ def apply_rope_hf(q, k, bridge, position_ids):
     position_embeddings = rotary_emb(q, position_ids)
     cos, sin = position_embeddings
     query_states, key_states = apply_multimodal_rotary_pos_emb(  # diff with Llama
-        q, k, cos, sin, bridge.hf_config.rope_scaling["mrope_section"]
+        q, k, cos, sin, get_hf_rope_scaling(bridge.hf_config).get("mrope_section", None)
     )
     return query_states, key_states
 

--- a/mbridge/models/deepseek_v3.py
+++ b/mbridge/models/deepseek_v3.py
@@ -13,7 +13,7 @@ from megatron.core.transformer import MLATransformerConfig
 from megatron.core.transformer.enums import AttnBackend
 
 from ..core import LLMBridge, register_model
-from ..utils.hf_config import get_hf_rope_theta
+from ..utils.hf_config import get_hf_rope_theta, get_hf_rope_scaling
 
 @register_model("deepseek_v3")
 class DeepseekV3Bridge(LLMBridge):
@@ -112,8 +112,7 @@ class DeepseekV3Bridge(LLMBridge):
             "original_max_position_embeddings": 4096,
             "type": "rope",
         }
-        if "rope_scaling" in hf_config and hf_config.rope_scaling is not None:
-            mla_rope_config.update(hf_config.rope_scaling)
+        mla_rope_config.update(get_hf_rope_scaling(hf_config))
         moe_layer_freq = [1] * hf_config.num_hidden_layers
         for i in range(
             min(hf_config.first_k_dense_replace, hf_config.num_hidden_layers)

--- a/mbridge/models/glm4_vl/__init__.py
+++ b/mbridge/models/glm4_vl/__init__.py
@@ -6,6 +6,7 @@ from megatron.core.transformer.enums import AttnBackend
 from ...core import register_model
 from .base_bridge import Glm4VLBridgeBase
 from .transformer_layer import Glm4TransformerLayer
+from mbridge.utils.hf_config import get_hf_rope_scaling
 
 """
 actually this only apply to glm-4.1v
@@ -126,7 +127,7 @@ class Glm4VLBridgeDense(Glm4VLBridgeBase):
         kwargs["image_token_id"] = self.hf_config.image_token_id
         kwargs["video_token_id"] = self.hf_config.video_token_id
         kwargs["spatial_merge_size"] = self.hf_config.vision_config.spatial_merge_size
-        kwargs["mrope_section"] = self.hf_config.rope_scaling.get("mrope_section", None)
+        kwargs["mrope_section"] = get_hf_rope_scaling(self.hf_config).get("mrope_section", None)
         kwargs["attention_backend"] = AttnBackend.fused
         kwargs["moe_router_dtype"] = "fp32"
         kwargs["disable_bf16_reduced_precision_matmul"] = True
@@ -275,7 +276,7 @@ class Glm4VLBridgeMoe(Glm4VLBridgeBase):
         kwargs["image_token_id"] = self.hf_config.image_token_id
         kwargs["video_token_id"] = self.hf_config.video_token_id
         kwargs["spatial_merge_size"] = self.hf_config.vision_config.spatial_merge_size
-        kwargs["mrope_section"] = self.hf_config.rope_scaling.get("mrope_section", None)
+        kwargs["mrope_section"] = get_hf_rope_scaling(self.hf_config).get("mrope_section", None)
         kwargs["attention_backend"] = AttnBackend.fused
         kwargs["disable_bf16_reduced_precision_matmul"] = True
         kwargs["persist_layer_norm"] = True

--- a/mbridge/models/llama.py
+++ b/mbridge/models/llama.py
@@ -3,7 +3,7 @@
 from ..core import LLMBridge, register_model
 from ..core.bridge import Bridge, register_model
 
-from mbridge.utils.hf_config import get_hf_rope_theta
+from mbridge.utils.hf_config import get_hf_rope_theta, get_hf_rope_scaling
 
 
 @register_model("llama")
@@ -79,14 +79,9 @@ class LLaMABridge(LLMBridge):
             dict: Dictionary of arguments for GPTModel initialization
         """
         rope_scaling_args = {}
-        if "rope_scaling" in self.hf_config:
-            if self.hf_config.rope_scaling is not None:
-                # assert (
-                #     self.hf_config.rope_scaling["type"] == "linear"
-                # ), "only linear scaling is supported for now"
-                rope_scaling_args["seq_len_interpolation_factor"] = (
-                    self.hf_config.rope_scaling["factor"]
-                )
+        rope_scaling = get_hf_rope_scaling(self.hf_config)
+        if rope_scaling:
+            rope_scaling_args["seq_len_interpolation_factor"] = rope_scaling["factor"]
         ret = dict(
             vocab_size=self.hf_config.vocab_size,
             max_sequence_length=self.hf_config.max_position_embeddings,

--- a/mbridge/models/qwen2_5_vl/__init__.py
+++ b/mbridge/models/qwen2_5_vl/__init__.py
@@ -1,5 +1,6 @@
 import re
 from copy import deepcopy
+from tkinter import NO
 from typing import Callable, Generator, Optional
 
 import torch
@@ -11,7 +12,7 @@ from ...core import VLMBridge, register_model
 from ...core.util import unwrap_model
 from .model import Qwen2_5VLModel
 from .transformer_config import get_vision_model_config, get_vision_projection_config
-from mbridge.utils.hf_config import get_hf_rope_theta
+from mbridge.utils.hf_config import get_hf_rope_theta, get_hf_rope_scaling
 
 
 class Qwen2_5VLSafeTensorIO(SafeTensorIO):
@@ -564,5 +565,5 @@ class Qwen2_5VLBridge(VLMBridge):
         return self._build_base_config(
             # qwen specific
             add_qkv_bias=True,
-            mrope_section=self.hf_config.rope_scaling["mrope_section"],
+            mrope_section=get_hf_rope_scaling(self.hf_config).get("mrope_section", None),
         )

--- a/mbridge/models/qwen3_5/base_bridge.py
+++ b/mbridge/models/qwen3_5/base_bridge.py
@@ -1,3 +1,4 @@
+import imp
 import inspect
 import logging
 from copy import deepcopy
@@ -16,7 +17,7 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 from mbridge.core import VLMBridge
 from mbridge.core.util import unwrap_model
 from mbridge.models.qwen3_5.qwen3_5_safetensor import Qwen3_5SafeTensorIO
-
+from mbridge.utils.hf_config import get_hf_rope_scaling
 
 class Qwen3_5VlBaseBridge(VLMBridge):
 
@@ -972,10 +973,10 @@ class Qwen3_5VlBaseBridge(VLMBridge):
                 language_max_sequence_length=self.hf_config.text_config.max_position_embeddings,
                 hf_config=self.hf_config,
                 hf_vision_cls=self.HfVisionClass,
-                language_rotary_percent=self.hf_config.text_config.rope_scaling.get(
+                language_rotary_percent=get_hf_rope_scaling(self.hf_config.text_config).get(
                     "partial_rotary_factor", 0.25
                 ),
-                language_rotary_base=self.hf_config.text_config.rope_scaling.get(
+                language_rotary_base=get_hf_rope_scaling(self.hf_config.text_config).get(
                     "rope_theta", 10000000
                 ),
                 position_embedding_type="mrope",

--- a/mbridge/models/qwen3_5/qwen3_5_vl_bridge.py
+++ b/mbridge/models/qwen3_5/qwen3_5_vl_bridge.py
@@ -1,8 +1,11 @@
+import imp
 import torch
 
 from mbridge.core import register_model
 from mbridge.models.qwen3_5.base_bridge import Qwen3_5VlBaseBridge
 from mbridge.models.qwen3_5.transformer_config import Qwen3_5VLTransformerConfig
+from mbridge.utils.hf_config import get_hf_rope_scaling
+
 
 _QWEN3p5VIT_DIRECT_MAPPING = {
     "vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
@@ -217,10 +220,10 @@ class Qwen3_5VlBridge(Qwen3_5VlBaseBridge):
             linear_value_head_dim=self.hf_config.text_config.linear_value_head_dim,
             linear_num_key_heads=self.hf_config.text_config.linear_num_key_heads,
             linear_num_value_heads=self.hf_config.text_config.linear_num_value_heads,
-            rotary_percent=self.hf_config.text_config.rope_scaling.get(
+            rotary_percent=get_hf_rope_scaling(self.hf_config.text_config).get(
                 "partial_rotary_factor", 0.25
             ),
-            mrope_section=self.hf_config.text_config.rope_scaling.get(
+            mrope_section=get_hf_rope_scaling(self.hf_config.text_config).get(
                 "mrope_section",
                 [11, 11, 10],
             ),
@@ -342,10 +345,10 @@ class Qwen3_5MoeVlBridge(Qwen3_5VlBaseBridge):
             linear_value_head_dim=self.hf_config.text_config.linear_value_head_dim,
             linear_num_key_heads=self.hf_config.text_config.linear_num_key_heads,
             linear_num_value_heads=self.hf_config.text_config.linear_num_value_heads,
-            rotary_percent=self.hf_config.text_config.rope_scaling.get(
+            rotary_percent=get_hf_rope_scaling(self.hf_config.text_config).get(
                 "partial_rotary_factor", 0.25
             ),
-            mrope_section=self.hf_config.text_config.rope_scaling.get(
+            mrope_section=get_hf_rope_scaling(self.hf_config.text_config).get(
                 "mrope_section",
                 [11, 11, 10],
             ),

--- a/mbridge/models/qwen3_omni_moe/__init__.py
+++ b/mbridge/models/qwen3_omni_moe/__init__.py
@@ -3,6 +3,8 @@ from copy import deepcopy
 from mbridge.core import register_model
 from mbridge.models.qwen3_omni_moe.base_bridge import Qwen3OmniBaseBridge
 from mbridge.models.qwen3_vl.transformer_config import Qwen3VLTransformerConfig
+from mbridge.utils.hf_config import get_hf_rope_scaling
+
 
 _QWEN3AUDIO_DIRECT_MAPPING = {
     "audio_model.ln_post.weight":"thinker.audio_tower.ln_post.weight",
@@ -271,7 +273,7 @@ class Qwen3OmniMoeBridge(Qwen3OmniBaseBridge):
             moe_router_pre_softmax=False,
             qk_layernorm=True,
             # qwen3vl specific
-            mrope_section=self.hf_config.text_config.rope_scaling.get(
+            mrope_section=get_hf_rope_scaling(self.hf_config.text_config).get(
                 "mrope_section",
                 [24, 20, 20],
             ),

--- a/mbridge/models/qwen3_vl/__init__.py
+++ b/mbridge/models/qwen3_vl/__init__.py
@@ -1,8 +1,11 @@
 from copy import deepcopy
+import imp
 
 from mbridge.core import register_model
 from mbridge.models.qwen3_vl.base_bridge import Qwen3VBaseBridge
 from mbridge.models.qwen3_vl.transformer_config import Qwen3VLTransformerConfig
+from mbridge.utils.hf_config import get_hf_rope_scaling
+
 
 _QWEN3VIT_DIRECT_MAPPING = {
     "vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
@@ -165,7 +168,7 @@ class Qwen3VLBridge(Qwen3VBaseBridge):
             distribute_saved_activations=False,
             cp_comm_type="p2p",
             # qwen3vl specific
-            mrope_section=self.hf_config.text_config.rope_scaling.get(
+            mrope_section=get_hf_rope_scaling(self.hf_config.text_config).get(
                 "mrope_section",
                 [24, 20, 20],
             ),
@@ -290,7 +293,7 @@ class Qwen3VLMoEBridge(Qwen3VBaseBridge):
             moe_router_pre_softmax=False,
             qk_layernorm=True,
             # qwen3vl specific
-            mrope_section=self.hf_config.text_config.rope_scaling.get(
+            mrope_section=get_hf_rope_scaling(self.hf_config.text_config).get(
                 "mrope_section",
                 [24, 20, 20],
             ),

--- a/mbridge/utils/hf_config.py
+++ b/mbridge/utils/hf_config.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Bytedance Ltd. and/or its affiliates
 
 from transformers import PretrainedConfig
+import warnings
 
 def get_hf_rope_theta(hf_config: PretrainedConfig) -> float:
     """Return RoPE base frequency theta.
@@ -34,6 +35,15 @@ def get_hf_rope_theta(hf_config: PretrainedConfig) -> float:
         f"{type(hf_config).__name__} has no rope_theta and no rope_parameters['rope_theta'] — "
         "cannot determine RoPE base."
     )
+
+def get_hf_rope_scaling(hf_config: PretrainedConfig) -> dict:
+    # For transformers <= 4.57.6
+    if hasattr(hf_config, "rope_scaling"):
+        return hf_config.rope_scaling
+    if hasattr(hf_config, "text_config") and hasattr(hf_config.text_config, "rope_scaling"):
+        return hf_config.text_config.rope_scaling
+    warnings.warn(f"rope_scaling not found in {type(hf_config).__name__}, keys: {hf_config.keys()}")
+    return {}
 
 
 def get_hf_rope_theta_from_attribute(hf_config: PretrainedConfig) -> str:


### PR DESCRIPTION
Now can cause bug:

File "/home/dpsk_a2a/actions-runner/_work/verl/verl/verl/workers/engine/megatron/transformer_impl.py", line 370, in initialize
(FullyAsyncTrainer pid=13617)     self._build_tf_config()
(FullyAsyncTrainer pid=13617)   File "/home/dpsk_a2a/actions-runner/_work/verl/verl/verl/workers/engine/megatron/transformer_impl.py", line 177, in _build_tf_config
(FullyAsyncTrainer pid=13617)     bridge = AutoBridge.from_config(self.model_config.hf_config, dtype=self.param_dtype)
(FullyAsyncTrainer pid=13617)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(FullyAsyncTrainer pid=13617)   File "/usr/local/lib/python3.12/dist-packages/mbridge/core/auto_bridge.py", line 48, in from_config
(FullyAsyncTrainer pid=13617)     return _MODEL_REGISTRY[model_type](hf_config, **kwargs)
(FullyAsyncTrainer pid=13617)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(FullyAsyncTrainer pid=13617)   File "/usr/local/lib/python3.12/dist-packages/mbridge/core/bridge.py", line 54, in __init__
(FullyAsyncTrainer pid=13617)     self.config = self._build_config()
(FullyAsyncTrainer pid=13617)                   ^^^^^^^^^^^^^^^^^^^^
(FullyAsyncTrainer pid=13617)   File "/usr/local/lib/python3.12/dist-packages/mbridge/models/qwen2_5_vl/__init__.py", line 567, in _build_config
(FullyAsyncTrainer pid=13617)     mrope_section=self.hf_config.rope_scaling["mrope_section"],
(FullyAsyncTrainer pid=13617)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(FullyAsyncTrainer pid=13617)   File "/usr/local/lib/python3.12/dist-packages/transformers/configuration_utils.py", line 164, in __getattribute__
(FullyAsyncTrainer pid=13617)     return super().__getattribute__(key)
(FullyAsyncTrainer pid=13617)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(FullyAsyncTrainer pid=13617)   File "/usr/local/lib/python3.12/dist-packages/transformers/configuration_utils.py", line 382, in rope_scaling
(FullyAsyncTrainer pid=13617)     return self.rope_parameters
(FullyAsyncTrainer pid=13617)            ^^^^^^^^^^^^^^^^^^^^
(FullyAsyncTrainer pid=13617)   File "/usr/local/lib/python3.12/dist-packages/transformers/configuration_utils.py", line 164, in __getattribute__
(FullyAsyncTrainer pid=13617)     return super().__getattribute__(key)
(FullyAsyncTrainer pid=13617)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(FullyAsyncTrainer pid=13617) AttributeError: 'Qwen2_5_VLConfig' object has no attribute 'rope_parameters'