### PR TITLE
 fix(qwen3_vl): guard split_deepstack_embs against None deepstack embeds

### DIFF
--- a/mbridge/models/qwen3_vl/utils.py
+++ b/mbridge/models/qwen3_vl/utils.py
@@ -185,7 +185,7 @@ def split_deepstack_embs(
     split_size = tp_size
     if cp_size > 1:
         split_size *= cp_size * 2
-    if split_size == 1 or visual_pos_masks is None:
+    if split_size == 1 or visual_pos_masks is None or deepstack_visual_embeds is None:
         return visual_pos_masks, deepstack_visual_embeds
 
     assert visual_pos_masks.dim() == 2

--- a/tests/test_qwen3_vl_split_deepstack.py
+++ b/tests/test_qwen3_vl_split_deepstack.py
@@ -1,0 +1,32 @@
+"""Regression test for split_deepstack_embs handling of None deepstack_visual_embeds.
+
+When a microbatch contains only text samples (no images), the visual encoder
+produces deepstack_visual_embeds=None while visual_pos_masks may still be a
+non-None tensor. The early-return guard previously only checked visual_pos_masks,
+so the function fell through to `for x in deepstack_visual_embeds` and crashed
+with TypeError: 'NoneType' object is not iterable.
+
+See ISEEKYAN/mbridge#47.
+"""
+
+import torch
+
+from mbridge.models.qwen3_vl.utils import split_deepstack_embs
+
+
+def test_returns_inputs_when_deepstack_is_none():
+    """Pure-text microbatch: deepstack=None should NOT crash."""
+    visual_pos_masks = torch.zeros(1, 8, dtype=torch.bool)
+
+    out_masks, out_embeds = split_deepstack_embs(
+        visual_pos_masks=visual_pos_masks,
+        deepstack_visual_embeds=None,
+        tp_size=2,
+        tp_rank=0,
+        cp_size=1,
+        cp_rank=0,
+        sequence_parallel=True,
+    )
+
+    assert out_embeds is None
+    assert torch.equal(out_masks, visual_pos_masks)


### PR DESCRIPTION
## Summary

  `split_deepstack_embs` crashes when a microbatch contains only text samples
  (no images). The visual encoder produces `deepstack_visual_embeds=None` while
  `visual_pos_masks` may still be non-None, so the existing early-return guard
  falls through and the function reaches `for x in deepstack_visual_embeds` with
  `None`.

  ## Stacktrace

  File "mbridge/models/qwen3_vl/model.py", line 401, in forward
      visual_pos_masks, deepstack_visual_embeds = split_deepstack_embs(
  File "mbridge/models/qwen3_vl/utils.py", line 226, in split_deepstack_embs
      for deepstack_visual_embed in deepstack_visual_embeds:
  TypeError: 'NoneType' object is not iterable