### PR TITLE
qwen3_5 tp/cp as dp

### DIFF
--- a/mbridge/core/util.py
+++ b/mbridge/core/util.py
@@ -519,6 +519,7 @@ def get_vision_cp_data(
     square_merge_size: int,
     cp_img_num: list[int],
     images_padded: list[bool],
+    group: torch.distributed.ProcessGroup = None,
 ):
     """Get vision data and grid_thw for context parallelism.
     Returns:
@@ -529,8 +530,10 @@ def get_vision_cp_data(
     """
     # we use the context parallelism size and context parallel group of LLM for vision model.
     # we only divide the number of images in each context parallel rank.
-    cp_size = mpu.get_context_parallel_world_size()
-    cp_rank = mpu.get_context_parallel_rank()
+    if group is None:
+        group = mpu.get_context_parallel_group()
+    cp_size = group.size()
+    cp_rank = group.rank()
     assert cp_size == len(cp_img_num)
 
     seqlens = torch.repeat_interleave(
@@ -561,7 +564,9 @@ def get_vision_cp_data(
 
 class AllGatherVisionEmbeddings(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, seqlens_on_cp_ranks):
+    def forward(ctx, input, seqlens_on_cp_ranks, group=None):
+        if group is None:
+            group = mpu.get_context_parallel_group()
         outputs = []
         for i in range(len(seqlens_on_cp_ranks)):
             o = torch.zeros(
@@ -571,10 +576,8 @@ class AllGatherVisionEmbeddings(torch.autograd.Function):
                 layout=input.layout,
             )
             outputs.append(o)
-        torch.distributed.all_gather(
-            outputs, input, group=mpu.get_context_parallel_group()
-        )
-        cp_rank = mpu.get_context_parallel_rank()
+        torch.distributed.all_gather(outputs, input, group=group)
+        cp_rank = group.rank()
         ctx.cp_rank = cp_rank
         ctx.save_for_backward(*seqlens_on_cp_ranks)
 
@@ -590,7 +593,7 @@ class AllGatherVisionEmbeddings(torch.autograd.Function):
         )
         end_idx = start_idx + seqlens_on_cp_ranks[cp_rank].sum()
         grad_output = grad_output[start_idx:end_idx]
-        return grad_output, None
+        return grad_output, None, None
 
 
 def preprocess_packed_seqs(

--- a/mbridge/models/qwen3_5/model.py
+++ b/mbridge/models/qwen3_5/model.py
@@ -316,6 +316,8 @@ class Qwen3_5VLModel(MegatronModule):
         vision_mask = None
         # TODO: this approach may need rethinking
         cp_size = mpu.get_context_parallel_world_size()
+        parallel_size = mpu.get_context_parallel_world_size()
+        group = mpu.get_context_parallel_group()
 
         # Track packed input_ids (THD format) for MTP use when remove_padding is enabled
         input_ids_packed = None
@@ -337,12 +339,12 @@ class Qwen3_5VLModel(MegatronModule):
 
             vision_embeds = None
             if vision_grid_thw is not None and vision_grid_thw.shape[0] > 0:
-                if cp_size > 1:
+                if parallel_size > 1:
                     if cp_img_num is None:
                         assert images_padded is None
                         vision_data, vision_grid_thw, cp_img_num, images_padded = (
                             qwen3vl_cp_split(
-                                cp_size,
+                                parallel_size,
                                 vision_data,
                                 vision_grid_thw,
                             )
@@ -354,6 +356,7 @@ class Qwen3_5VLModel(MegatronModule):
                             self.square_merge_size,
                             cp_img_num,
                             images_padded,
+                            group,
                         )
                     )
                     vision_grid_thw = collapse_thw(vision_grid_thw)
@@ -374,10 +377,11 @@ class Qwen3_5VLModel(MegatronModule):
                         device=vision_data.device,
                         dtype=torch.bfloat16,
                     )
-                if cp_size > 1:
+                if parallel_size > 1:
                     vision_embeds = AllGatherVisionEmbeddings.apply(
                         vision_embeds,
                         seqlen_on_cp_ranks,
+                        group,
                     )
 
             combined_embeddings = self.language_model._modules["embedding"](


### PR DESCRIPTION
Qwen3.5 vit model is the hf transformer model, which do not parallel with tp/cp.
To improve performance， apply tp / cp as dp.