### PR TITLE
fix save_weights_fast_with_mtp

### DIFF
--- a/example/qwen3_5/test_save_mtp.py
+++ b/example/qwen3_5/test_save_mtp.py
@@ -4,7 +4,7 @@ Usage:
   torchrun --nproc_per_node=8 example/qwen3_5/test_save_mtp.py \
       --model_path hf-hub/Qwen/Qwen3.5-4B \
       --save_path qwen3_5_4b_saved \
-      --tp 2 --pp 1 --cp 1 --ep 1
+      --tp 2 --pp 2 --cp 1 --ep 1
 """
 
 import argparse
@@ -152,6 +152,22 @@ def main() -> None:
         print("Save finished.")
         print("Comparing saved HF weights with the source HF weights.")
         compare_saved_weights(args.model_path, args.save_path)
+
+    distributed_save_path = f"{args.save_path}_distributed_filesystem"
+    if rank == 0:
+        print(f"Saving Qwen3.5 model to {distributed_save_path} with DFS fast path")
+    bridge.save_weights(
+        model,
+        distributed_save_path,
+        memory_efficient=True,
+        distributed_filesystem=True,
+    )
+
+    torch.distributed.barrier()
+    if rank == 0:
+        print("Distributed filesystem save finished.")
+        print("Comparing DFS-saved HF weights with the source HF weights.")
+        compare_saved_weights(args.model_path, distributed_save_path)
 
     torch.distributed.destroy_process_group()
 

--- a/mbridge/core/bridge.py
+++ b/mbridge/core/bridge.py
@@ -1025,6 +1025,14 @@ class Bridge(ABC):
 
             assert iter_pp_rank == self.mpu.pp_rank
 
+            if (
+                self.mpu.pp_size > 1
+                and "embedding.word_embeddings.weight" in name
+                and getattr(param, "shared", False)
+                and getattr(param, "shared_embedding", False)
+            ):
+                continue
+
             # EP
             if ".mlp.experts.linear_fc" in name and self.mpu.ep_size >= 1:
                 num_experts = self.config.num_moe_experts

--- a/mbridge/models/qwen3_5/base_bridge.py
+++ b/mbridge/models/qwen3_5/base_bridge.py
@@ -76,6 +76,7 @@ class Qwen3_5VlBaseBridge(VLMBridge):
         config = deepcopy(self.config)
         config.num_layers = 1
         config.linear_attention_freq = [0]
+        config.num_layers_in_first_pipeline_stage = None
         config.num_layers_in_last_pipeline_stage = 1
 
         extra_args = {}


### PR DESCRIPTION
This PR includes two fixes: 
1. The first fix addresses an issue where, when MTP is enabled, save_weights_fast did not correctly handle the `duplicated MTP` embedding. As a result, the layer with this name was saved twice, which triggered the shard count check failure.; 

2. the other fixes an MTP construction error triggered when `pp > 0` and `num_layers_in_first_pipeline_stage` is set. 
<img width="722" height="140" alt="image" src="https://github.com/user-attachments/assets/9fcb5a4f-2407-4bef-aace-53d3238954d7" />
