### PR TITLE
Fix MTP sp_input_ids preparation for TP+CP+PP parallelism in Qwen3.5/Qwen3.6

### DIFF
--- a/example/qwen3_5/test_mtp_logits.py
+++ b/example/qwen3_5/test_mtp_logits.py
@@ -77,7 +77,7 @@ from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from transformers import AutoTokenizer
 
 from mbridge import AutoBridge
-from mbridge.core.util import unwrap_model
+from mbridge.core.util import split_data_cp_rank, unwrap_model
 
 # ---------------------------------------------------------------------------
 # Distributed helpers
@@ -214,6 +214,12 @@ def make_fwd_fn_with_labels(input_ids_gpu: torch.Tensor):
         _ = next(data_iterator)  # consume iterator (input captured via closure)
         # Shift-right labels: target[i] = input[i+1]; pad last position with 0
         labels = F.pad(input_ids_gpu[:, 1:], (0, 1), value=0)  # [B, S]
+
+        cp_size = mpu.get_context_parallel_world_size()
+        if cp_size > 1:
+            labels = split_data_cp_rank(
+                labels.permute(1, 0).contiguous(), cp_size, seq_dim=0
+            ).permute(1, 0).contiguous()
 
         output_tensor = model(
             input_ids=input_ids_gpu,

--- a/example/qwen3_5/test_mtp_roll_correctness.py
+++ b/example/qwen3_5/test_mtp_roll_correctness.py
@@ -1,0 +1,208 @@
+"""Verify MTP sp_input_ids preparation produces correct rolled token IDs.
+
+Core invariant being tested
+---------------------------
+After ``split_data_cp_rank`` (CP split) followed by ``roll_tensor(shifts=-1)``,
+each position's value must equal the *next* token in the original sequence.
+The last token of the full sequence should become 0.
+
+This test catches the TP-boundary bug where pre-scattering input_ids by TP
+*before* rolling causes ``roll_tensor`` to wrap within each TP chunk instead
+of referencing the correct cross-TP next token.  ``roll_tensor`` only handles
+CP boundaries (via isend/irecv), not TP boundaries.
+
+Two methods are compared:
+  Method A (correct):  CP-split only  → roll → check
+  Method B (buggy):    TP-scatter + CP-split → roll → check
+
+Run
+---
+  torchrun --nproc_per_node=4 example/qwen3_5/test_mtp_roll_correctness.py
+
+  (TP=2, CP=2 → 4 GPUs minimum)
+
+  Optional flags:
+    --tp 2 --cp 2        (default)
+    --seq_len 32         (must be divisible by tp * cp * 2)
+"""
+
+import argparse
+
+import torch
+from megatron.core import parallel_state as mpu
+from megatron.core import tensor_parallel
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+from mbridge.core.util import split_data_cp_rank
+
+# roll_tensor lives in MTP module
+from megatron.core.transformer.multi_token_prediction import roll_tensor
+
+
+def get_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--tp", type=int, default=2)
+    p.add_argument("--cp", type=int, default=2)
+    p.add_argument("--seq_len", type=int, default=32)
+    return p.parse_args()
+
+
+def init_distributed(tp, cp):
+    torch.distributed.init_process_group("nccl")
+    torch.cuda.set_device(torch.distributed.get_rank() % torch.cuda.device_count())
+    mpu.initialize_model_parallel(
+        tensor_model_parallel_size=tp,
+        context_parallel_size=cp,
+    )
+    model_parallel_cuda_manual_seed(0)
+
+
+def gather_from_cp(tensor, seq_dim, cp_size, cp_group):
+    """Inverse of split_data_cp_rank: all-gather and reorder bidirectional CP chunks."""
+    chunk_size = tensor.shape[seq_dim] // 2
+    tensor = tensor.view(
+        *tensor.shape[:seq_dim],
+        2,
+        chunk_size,
+        *tensor.shape[seq_dim + 1 :],
+    )
+    gathered = [torch.zeros_like(tensor) for _ in range(cp_size)]
+    torch.distributed.all_gather(gathered, tensor, group=cp_group)
+
+    reordered = [None] * (2 * cp_size)
+    for r in range(cp_size):
+        reordered[r] = gathered[r].select(seq_dim, 0)
+        reordered[2 * cp_size - r - 1] = gathered[r].select(seq_dim, 1)
+    return torch.cat(reordered, dim=seq_dim)
+
+
+def build_reference(seq_len: int) -> torch.Tensor:
+    """Reference rolled sequence: [1, 2, ..., S-1, 0]."""
+    ref = torch.arange(1, seq_len + 1, device="cuda").unsqueeze(0)
+    ref[0, -1] = 0
+    return ref
+
+
+def test_method_a(input_ids, cp_size, cp_group):
+    """Method A (correct): CP-split only → roll → gather → compare.
+
+    Returns
+    -------
+    (rolled_full, ok) : (Tensor[1, S], bool)
+    """
+    sp = input_ids  # [1, S], replicated across TP ranks
+    if cp_size > 1:
+        sp = sp.permute(1, 0).contiguous()
+        sp = split_data_cp_rank(sp, cp_size, seq_dim=0)
+        sp = sp.permute(1, 0).contiguous()
+
+    rolled, _ = roll_tensor(sp, shifts=-1, dims=-1, cp_group=cp_group)
+
+    # Gather back across CP
+    full = rolled.permute(1, 0).contiguous()
+    if cp_size > 1:
+        full = gather_from_cp(full, seq_dim=0, cp_size=cp_size, cp_group=cp_group)
+    full = full.permute(1, 0).contiguous()
+
+    ref = build_reference(input_ids.shape[1])
+    ok = torch.equal(full, ref)
+    return full, ok
+
+
+def test_method_b(input_ids, cp_size, cp_group, tp_group):
+    """Method B (buggy): TP-scatter + CP-split → roll → gather → compare.
+
+    Returns
+    -------
+    (rolled_full, ok) : (Tensor[1, S], bool)
+    """
+    tp_size = tp_group.size()
+
+    sp = input_ids.permute(1, 0).contiguous()  # [S, 1]
+    sp = tensor_parallel.scatter_to_sequence_parallel_region(sp)  # [S/TP, 1]
+    if cp_size > 1:
+        sp = split_data_cp_rank(sp, cp_size, seq_dim=0)  # [S/(TP*CP*2), 1]
+    sp = sp.permute(1, 0).contiguous()  # [1, S/(TP*CP*2)]
+
+    rolled, _ = roll_tensor(sp, shifts=-1, dims=-1, cp_group=cp_group)
+
+    # Gather back across CP
+    full = rolled.permute(1, 0).contiguous()
+    if cp_size > 1:
+        full = gather_from_cp(full, seq_dim=0, cp_size=cp_size, cp_group=cp_group)
+
+    # Gather back across TP
+    chunks = [torch.zeros_like(full) for _ in range(tp_size)]
+    torch.distributed.all_gather(chunks, full, group=tp_group)
+    full = torch.cat(chunks, dim=0)  # [S, 1]
+    full = full.permute(1, 0).contiguous()
+
+    ref = build_reference(input_ids.shape[1])
+    ok = torch.equal(full, ref)
+    return full, ok
+
+
+def main():
+    args = get_args()
+    init_distributed(tp=args.tp, cp=args.cp)
+
+    rank = torch.distributed.get_rank()
+    tp_size = mpu.get_tensor_model_parallel_world_size()
+    cp_size = mpu.get_context_parallel_world_size()
+    cp_group = mpu.get_context_parallel_group()
+    tp_group = mpu.get_tensor_model_parallel_group()
+
+    S = args.seq_len
+    assert S % (tp_size * cp_size * 2) == 0, (
+        f"seq_len={S} must be divisible by tp*cp*2={tp_size * cp_size * 2}"
+    )
+
+    input_ids = torch.arange(S, device="cuda").unsqueeze(0)  # [1, S]
+
+    # --- Test Method A ---
+    full_a, ok_a = test_method_a(input_ids, cp_size, cp_group)
+    # --- Test Method B ---
+    full_b, ok_b = test_method_b(input_ids, cp_size, cp_group, tp_group)
+
+    if rank == 0:
+        ref = build_reference(S)
+        print(f"\nConfig: TP={tp_size}, CP={cp_size}, S={S}")
+        print(f"{'=' * 64}")
+        print(f"Reference (correct next-token IDs):")
+        print(f"  {ref[0, :16].tolist()} ...")
+        print()
+
+        print(f"Method A (CP-split only, do_scatter=True):")
+        print(f"  {full_a[0, :16].tolist()} ...")
+        print(f"  Correct: {ok_a}")
+        print()
+
+        print(f"Method B (TP-scatter + CP-split, do_scatter=False):")
+        print(f"  {full_b[0, :16].tolist()} ...")
+        print(f"  Correct: {ok_b}")
+
+        # Find mismatched positions in Method B
+        mismatches = (full_b != ref).nonzero(as_tuple=True)
+        if len(mismatches[1]) > 0:
+            print(f"\n  Method B errors at positions: {mismatches[1].tolist()}")
+            for pos in mismatches[1].tolist():
+                print(
+                    f"    pos={pos}: got {full_b[0, pos].item()}, "
+                    f"expected {ref[0, pos].item()}"
+                )
+
+        print(f"\n{'=' * 64}")
+        assert ok_a, "[FAIL] Method A should be correct but isn't!"
+        assert not ok_b, (
+            "[UNEXPECTED] Method B passed — expected TP-boundary errors. "
+            "This test assumes TP > 1."
+        )
+        print("[PASS] Method A is correct, Method B has TP-boundary errors as expected.")
+        print(f"{'=' * 64}\n")
+
+    torch.distributed.barrier()
+    torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/mbridge/models/qwen3_5/model.py
+++ b/mbridge/models/qwen3_5/model.py
@@ -509,11 +509,9 @@ class Qwen3_5VLModel(MegatronModule):
                 # would cause incorrect "next token" lookups at TP boundaries.
                 sp_input_ids = input_ids
                 if input_ids is not None and cp_size > 1:
-                    sp_input_ids = input_ids.permute(1, 0).contiguous()
                     sp_input_ids = split_data_cp_rank(
-                        sp_input_ids, cp_size, seq_dim=0
+                        input_ids, cp_size, seq_dim=1
                     )
-                    sp_input_ids = sp_input_ids.permute(1, 0).contiguous()
                 self.language_model.init_mtp_embedding_scatter(do_scatter=True)
 
         return self.language_model(

--- a/mbridge/models/qwen3_5/model.py
+++ b/mbridge/models/qwen3_5/model.py
@@ -502,25 +502,19 @@ class Qwen3_5VLModel(MegatronModule):
                 # THD mode: embedding wrapper must scatter (do_scatter=True).
                 self.language_model.init_mtp_embedding_scatter(do_scatter=True)
             else:
+                # BSHD mode: only CP-split input_ids, let the embedding wrapper
+                # handle TP scatter after embedding.  This is critical because
+                # MTP's roll_tensor only exchanges boundary tokens across CP ranks
+                # (via isend/irecv), NOT across TP ranks.  Pre-scattering by TP
+                # would cause incorrect "next token" lookups at TP boundaries.
                 sp_input_ids = input_ids
-
-                if input_ids is not None and combined_embeddings is not None:
-                    # BSHD mode: input_ids may arrive already SP-scattered (shape [B, S/TP])
-                    # or still full-length (shape [B, S]).  combined_embeddings has already been
-                    # CP-split and TP-scattered by this point, so its dim-0 equals S/(TP*CP*2).
-                    # We need sp_input_ids to be [B, S/(TP*CP*2)] so that MTP embedding output
-                    # [S/(TP*CP*2), B, H] matches hidden_states [S/(TP*CP*2), B, H].
-                    # Step 1: TP scatter along seq dim: [B, S] -> [B, S/TP]
-                    # Step 2: CP split along seq dim:   [B, S/TP] -> [B, S/(TP*CP*2)]
-                    if input_ids.shape[1] != combined_embeddings.shape[0]:
-                        sp_input_ids = input_ids.permute(1, 0).contiguous()
-                        sp_input_ids = tensor_parallel.scatter_to_sequence_parallel_region(sp_input_ids)
-                        if cp_size > 1:
-                            # CP split: [S/TP, B] -> [S/(TP*CP*2), B]
-                            sp_input_ids = split_data_cp_rank(sp_input_ids, cp_size, seq_dim=0)
-                        sp_input_ids = sp_input_ids.permute(1, 0).contiguous()
-                    # sp_input_ids is now [B, S/(TP*CP*2)]: embedding wrapper must NOT scatter again.
-                    self.language_model.init_mtp_embedding_scatter(do_scatter=False)
+                if input_ids is not None and cp_size > 1:
+                    sp_input_ids = input_ids.permute(1, 0).contiguous()
+                    sp_input_ids = split_data_cp_rank(
+                        sp_input_ids, cp_size, seq_dim=0
+                    )
+                    sp_input_ids = sp_input_ids.permute(1, 0).contiguous()
+                self.language_model.init_mtp_embedding_scatter(do_scatter=True)
 
         return self.language_model(
             input_ids=sp_input_ids,


### PR DESCRIPTION
**Problem**

When `Multi-Token Prediction (MTP)` is enabled with Tensor Parallelism (TP) and Context Parallelism (CP), the `sp_input_ids` tensor was incorrectly prepared in `Qwen3_5VLModel.forward()` (BSHD mode). Two bugs existed:

1. TP scatter before roll: input_ids was scattered across TP ranks via `scatter_to_sequence_parallel_region` before being passed to `roll_tensor`. However, `roll_tensor` only handles CP boundary communication (via isend/irecv), not TP boundaries. This caused each TP chunk to wrap within itself during the roll, `producing incorrect "next token" IDs at TP boundaries` and silently degrading MTP accuracy.

2. PP last-stage skipped: The entire `sp_input_ids` processing block was guarded by combined_embeddings is not None, which is only true on the first PP stage. On the last PP stage (where MTP actually runs), `sp_input_ids` was left as the raw full-length input_ids, causing a `shape mismatch` in _concat_embeddings:
<img width="761" height="230" alt="image" src="https://github.com/user-attachments/assets/39946d47-0bbd-4fa8-a677-bfc3ec40a44f" />

**Fix**
1. `Remove TP scatter from sp_input_ids`: Only apply split_data_cp_rank (CP-split) to input_ids. Delegate TP scattering to the _SPScatterEmbeddingWrapper which performs it after embedding lookup via `init_mtp_embedding_scatter(do_scatter=True)`.
2. `Remove combined_embeddings is not None guard`: The sp_input_ids preparation now runs unconditionally on all PP stages.

**Verification**
1. `Token ID Correctness` (test_mtp_roll_correctness.py)
A lightweight test (no model checkpoint required) that directly verifies the core invariant of MTP's `sp_input_ids` preparation. It constructs a synthetic sequence [0, 1, ..., 31] with TP=2, CP=2 (4 GPUs) and compares two methods:

    Method A (fixed): CP-split only → roll_tensor → gather
    Method B (buggy): TP-scatter → CP-split → roll_tensor → gather
After rolling, each position i should contain i+1 (the next token), with the last position set to 0.
<img width="753" height="308" alt="image" src="https://github.com/user-attachments/assets/beac5845-3488-465a-98bc-bfa59cf221e1" />


2. `MTP Logits Accuracy` (test_mtp_logits.py) 
End-to-end test on Qwen3.5-4B (H20 GPUs), comparing MTP Head 0 and Main Head top-1 accuracy:
<img width="800" height="145" alt="image" src="https://github.com/user-attachments/assets/18cc5f18-50d6-4479-89b1-656e8ac9e903" />

Main head accuracy is identical across all configurations, confirming the bug is isolated to the MTP branch.
Before fix, MTP accuracy degrades with more parallelism (29% → 15% → crash). After fix, it remains stable (~62-65%).
The PP=2 case crashed before fix due to the combined_embeddings is not None guard skipping sp_input_ids processing on the last PP stage.


