### PR TITLE
[fix]: bugfix for RAY_EXPERIMENTAL_NOSET_ASCEND/CUDA_RT_VISIBLE_DEVICES in RL

### DIFF
--- a/mbridge/models/ext/deepseek_v3/dequant_fp8_safetensor_io.py
+++ b/mbridge/models/ext/deepseek_v3/dequant_fp8_safetensor_io.py
@@ -10,7 +10,7 @@ from safetensors import safe_open
 from safetensors.torch import save_file
 
 from mbridge.core.safetensor_io import SafeTensorIO
-from mbridge.utils.device import get_device_name
+from mbridge.utils.device import get_device_name, get_device_id
 
 from .kernel import weight_dequant
 
@@ -25,6 +25,7 @@ class DequantFP8SafeTensorIO(SafeTensorIO):
         weight_to_file_map = self.index
         hf_dir = self.hf_dir
         ret = {}
+        load_device = f"{get_device_name()}:{get_device_id()}"
 
         assert weight_to_file_map is not None, "index is not found"
         file_to_weight_map = defaultdict(list)
@@ -34,7 +35,7 @@ class DequantFP8SafeTensorIO(SafeTensorIO):
         for filename, weight_names in file_to_weight_map.items():
             safetensor_file = os.path.join(hf_dir, filename)
             with safe_open(
-                safetensor_file, framework="pt", device=get_device_name()
+                safetensor_file, framework="pt", device=load_device
             ) as f:
                 for name in weight_names:
                     weight = f.get_tensor(name)
@@ -52,7 +53,7 @@ class DequantFP8SafeTensorIO(SafeTensorIO):
                                         hf_dir, weight_to_file_map[scale_inv_name]
                                     ),
                                     framework="pt",
-                                    device=get_device_name(),
+                                    device=load_device,
                                 ) as f2:
                                     scale_inv = f2.get_tensor(scale_inv_name)
                             ret[name] = weight_dequant(weight, scale_inv)


### PR DESCRIPTION
If using a reinforcement learning framework, such as Verl, and setting the global variables `RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES` or `RAY_EXPERIMENTAL_NOSET_CUDA_RT_VISIBLE_DEVICES`, the behavior changes from each card only being able to see its own card (i.e., each card is rank 0) to all cards in the device being visible. However, `device = get_device_name()` implies that tensors are loaded on rank 0 by default, which can easily lead to all cards' tensors being loaded on rank 0, causing an OOM (Out of Memory) error in **weight = f.get_tensor(name)**.

Therefore, in this PR, the tensor is loaded from the current device rank obtained by torch instead of rank 0 by default.